### PR TITLE
EV-1293: Generate Form Submission Binary

### DIFF
--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const faker = require('faker/locale/en_CA')
+const faker = require("faker/locale/en_CA")
 
 // use docopt for arg parsing
 // requires --date and --destination options
@@ -8,8 +8,8 @@ const faker = require('faker/locale/en_CA')
 const { PROOF_URL, PROOF_FORM_ID } = process.env
 
 // part of the curl command
-console.log('PROOF_URL', PROOF_URL)
-console.log('PROOF_FORM_ID', PROOF_FORM_ID)
+console.log("PROOF_URL", PROOF_URL)
+console.log("PROOF_FORM_ID", PROOF_FORM_ID)
 
 const YUKON_COMMUNITIES = [
   "Beaver Creek",
@@ -29,9 +29,7 @@ const YUKON_COMMUNITIES = [
   "Whitehorse",
 ]
 
-SUPPORT_ENTRY_DOCUMENTS = [
-
-]
+SUPPORT_ENTRY_DOCUMENTS = [""]
 
 const IDENTIFICATION = [
   "Passport",
@@ -66,67 +64,128 @@ const POINTS_OF_ENTRY = [
 const AIRLINES_TO_THE_YUKON = ["Air North", "Air Canada"]
 
 const custom_fakes = {
-  ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
-  NUMBERS: '0123456789'.split(''),
-  fullName () {
+  ALPHABET: "abcdefghijklmnopqrstuvwxyz".split(""),
+  NUMBERS: "0123456789".split(""),
+  fullName() {
     return `${faker.name.firstName()} ${faker.name.lastName()}`
   },
-  yukonAddress () {
-    return `${faker.address.streetAddress()}, ${faker.random.arrayElement(YUKON_COMMUNITIES)}, YT, ${faker.address.zipCode()}`
+  yukonAddress() {
+    return `${faker.address.streetAddress()}, ${faker.random.arrayElement(
+      YUKON_COMMUNITIES
+    )}, YT, ${faker.address.zipCode()}`
   },
-  yukonLicensePlate () {
+  yukonLicensePlate() {
     return faker.random.alphaNumeric(5).toUpperCase()
   },
-  yukonPhoneNumber () {
+  yukonPhoneNumber() {
     return faker.phone.phoneNumber("867-###-###")
   },
-  flightNumber () {
-    return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(faker.random.number({ min: 1, max: 4}))}`
+  flightNumber() {
+    return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(
+      faker.random.number({ min: 1, max: 4 })
+    )}`
   },
-  alpha (count) {
+  alpha(count) {
     let wholeString = ""
-    for(let i = 0; i < (count || 1); i++) {
+    for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.ALPHABET)
     }
     return wholeString
   },
-  numeric (count) {
+  numeric(count) {
     let wholeString = ""
-    for(let i = 0; i < (count || 1); i++) {
+    for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.NUMBERS)
     }
     return wholeString
   },
 }
 
+// Conditional Form Logic Helpers
+const TRAVELLER_IDENTIFIERS = Object.freeze({
+  RESIDENT: 1,
+  NON_RESIDENT_NON_TRANSIT: 2,
+  NON_RESIDENT: 3,
+})
+const HAS_COVID_SYMPTOMS = Object.freeze({
+  YES: 1,
+  NO: 2,
+})
+const TRAVEL_MODE = Object.freeze({
+  VEHICLE: 1,
+  FLIGHT: 2,
+})
+const DESTINATIONS = Object.freeze([...YUKON_COMMUNITIES, "Outside Yukon"])
+const OUTSIDE_YUKON = DESTINATIONS.length
+
+const travellerIdentifier = faker.random.objectElement(TRAVELLER_IDENTIFIERS)
+const hasCovidSymtoms = faker.random.objectElement(HAS_COVID_SYMPTOMS)
+const travelMode = faker.random.objectElement(TRAVEL_MODE)
+const destination = faker.random.arrayElement(DESTINATIONS)
 
 const submission = {
-  traveller_identifier: faker.random.number({ min: 1, max: 3}),
+  traveller_identifier: travellerIdentifier,
   traveller_name: custom_fakes.fullName(),
   traveller_address: custom_fakes.yukonAddress(),
   traveller_phone: custom_fakes.yukonPhoneNumber(),
-  traveller_purpose: faker.random.number({ min: 1, max: 5}),
-  support_entrydocument: '',
-  outside_canada: faker.random.number({ min: 1, max: 2}),
-  locations_visited_14_days: faker.random.arrayElement([faker.address.city(), faker.address.country()]),
-  non_residient_not_transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
-  'non_resident.transit_plan': faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
-  resident_yukon_declaration: faker.random.number({ min: 1, max: 2}),
-  covid_symptoms_yes_no: faker.random.number({ min: 1, max: 2}),
-  covid_symptoms: faker.random.number({ min: 1, max: 3}),
-  non_resident_not_transit_declaration: faker.random.number({ min: 1, max: 2}),
-  non_resident_transit_declaration: faker.random.number({ min: 1, max: 2}),
-  point_of_entry_travel: faker.random.arrayElement(POINTS_OF_ENTRY.map((_, index) => index + 1)),
-  office_use_travel_mode: faker.random.number({ min: 1, max: 2}),
-  office_use_license_plate: custom_fakes.yukonLicensePlate(),
-  office_use_airline: faker.random.arrayElement(AIRLINES_TO_THE_YUKON),
-  office_use_flight_number: custom_fakes.flightNumber(),
+  traveller_purpose: faker.random.number({ min: 1, max: 5 }),
+  support_entrydocument: faker.random.arrayElement(SUPPORT_ENTRY_DOCUMENTS),
+  outside_canada: faker.random.number({ min: 1, max: 2 }),
+  locations_visited_14_days: faker.random.arrayElement([
+    faker.address.city(),
+    faker.address.country(),
+  ]),
+  non_residient_not_transit_plan:
+    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
+      ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
+      : "",
+  "non_resident.transit_plan":
+    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
+      ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
+      : "",
+  resident_yukon_declaration:
+    travellerIdentifier === TRAVELLER_IDENTIFIERS.RESIDENT
+      ? faker.random.number({ min: 1, max: 2 })
+      : null,
+  covid_symptoms_yes_no: hasCovidSymtoms,
+  covid_symptoms:
+    hasCovidSymtoms === HAS_COVID_SYMPTOMS.YES
+      ? faker.random.number({ min: 1, max: 3 })
+      : null,
+  non_resident_not_transit_declaration:
+    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
+      ? faker.random.number({ min: 1, max: 2 })
+      : null,
+  non_resident_transit_declaration:
+    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
+      ? faker.random.number({ min: 1, max: 2 })
+      : null,
+  point_of_entry_travel: faker.random.arrayElement(
+    POINTS_OF_ENTRY.map((_, index) => index + 1)
+  ),
+  office_use_travel_mode: travelMode,
+  office_use_license_plate:
+    travelMode === TRAVEL_MODE.VEHICLE ? custom_fakes.yukonLicensePlate() : "",
+  office_use_airline:
+    travelMode === TRAVEL_MODE.FLIGHT
+      ? faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
+      : "",
+  office_use_flight_number:
+    travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : "",
   office_use_date_entry: faker.date.recent(90).toLocaleDateString(),
   office_use_time_entry: faker.date.recent().toLocaleTimeString(),
-  destionation_dropdown: faker.random.arrayElement([...YUKON_COMMUNITIES, 'Outside Yukon']),
-  destination_other: faker.address.city(),
-  office_use_id: faker.random.arrayElement(IDENTIFICATION.map((_, index) => index + 1)),
-  office_use_additional_remarks: faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
+  destionation_dropdown: faker.random.arrayElement([
+    ...YUKON_COMMUNITIES,
+    "Outside Yukon",
+  ]),
+  destination_other:
+    destination === OUTSIDE_YUKON ? faker.address.city() : null,
+  office_use_id: faker.random.arrayElement(
+    IDENTIFICATION.map((_, index) => index + 1)
+  ),
+  office_use_additional_remarks: faker.lorem.sentences(
+    faker.random.number({ min: 0, max: 3 })
+  ),
 }
 
 console.log(submission, null, 2)

--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const faker = require('faker')
+
+console.log(process.argv)
+
+const { PROOF_URL, PROOF_FORM_ID } = process.env
+
+// part of the curl command
+console.log('PROOF_URL', PROOF_URL)
+console.log('PROOF_FORM_ID', PROOF_FORM_ID)
+
+const submission = {
+
+}
+
+console.log(submission, null, 2)
+
+// post data via http or axios

--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -1,71 +1,63 @@
 #!/usr/bin/env node
-const faker = require("faker/locale/en_CA")
 
-// use docopt for arg parsing
-// requires --date and --destination options
-// console.log(process.argv)
-
-const { PROOF_URL, PROOF_FORM_ID } = process.env
-
-// part of the curl command
-console.log("PROOF_URL", PROOF_URL)
-console.log("PROOF_FORM_ID", PROOF_FORM_ID)
+const { docopt } = require('docopt')
+const faker = require('faker/locale/en_CA')
 
 const YUKON_COMMUNITIES = [
-  "Beaver Creek",
-  "Burwash Landing",
-  "Carcross and Tagish",
-  "Carmacks",
-  "Dawson City",
-  "Faro",
-  "Haines Junction",
-  "Mayo",
-  "Mount Lorne",
-  "Old Crow",
-  "Pelly Crossing",
-  "Ross River",
-  "Teslin",
-  "Watson Lake",
-  "Whitehorse",
+  'Beaver Creek',
+  'Burwash Landing',
+  'Carcross and Tagish',
+  'Carmacks',
+  'Dawson City',
+  'Faro',
+  'Haines Junction',
+  'Mayo',
+  'Mount Lorne',
+  'Old Crow',
+  'Pelly Crossing',
+  'Ross River',
+  'Teslin',
+  'Watson Lake',
+  'Whitehorse',
 ]
 
-SUPPORT_ENTRY_DOCUMENTS = [""]
+SUPPORT_ENTRY_DOCUMENTS = ['']
 
 const IDENTIFICATION = [
-  "Passport",
-  "Birth Certificate",
+  'Passport',
+  'Birth Certificate',
   "Driver's License",
-  "Canadian military identification card",
-  "Government-issued identification card",
-  "Canadian citizenship card",
-  "Status card",
+  'Canadian military identification card',
+  'Government-issued identification card',
+  'Canadian citizenship card',
+  'Status card',
 ]
 
 const POINTS_OF_ENTRY = [
-  "Whitehorse Airport",
-  "Alaska Hwy",
-  "Stewart Cassiar Hwy",
-  "Dempster Hwy",
-  "Dawson City Airport",
-  "Watson Lake Airport",
-  "Mayo Airport",
-  "Beaver Creek Airport",
-  "Burwash Landing Airport",
-  "Carcross Airport",
-  "Carmacks Airport",
-  "Faro Airport",
-  "Haines Junction Airport",
-  "Old Crow Airport",
-  "Pelly Crossing Airport",
-  "Ross River Airport",
-  "Teslin Airport",
+  'Whitehorse Airport',
+  'Alaska Hwy',
+  'Stewart Cassiar Hwy',
+  'Dempster Hwy',
+  'Dawson City Airport',
+  'Watson Lake Airport',
+  'Mayo Airport',
+  'Beaver Creek Airport',
+  'Burwash Landing Airport',
+  'Carcross Airport',
+  'Carmacks Airport',
+  'Faro Airport',
+  'Haines Junction Airport',
+  'Old Crow Airport',
+  'Pelly Crossing Airport',
+  'Ross River Airport',
+  'Teslin Airport',
 ]
 
-const AIRLINES_TO_THE_YUKON = ["Air North", "Air Canada"]
+const AIRLINES_TO_THE_YUKON = ['Air North', 'Air Canada']
 
 const custom_fakes = {
-  ALPHABET: "abcdefghijklmnopqrstuvwxyz".split(""),
-  NUMBERS: "0123456789".split(""),
+  ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
+  NUMBERS: '0123456789'.split(''),
   fullName() {
     return `${faker.name.firstName()} ${faker.name.lastName()}`
   },
@@ -78,7 +70,7 @@ const custom_fakes = {
     return faker.random.alphaNumeric(5).toUpperCase()
   },
   yukonPhoneNumber() {
-    return faker.phone.phoneNumber("867-###-###")
+    return faker.phone.phoneNumber('867-###-###')
   },
   flightNumber() {
     return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(
@@ -86,14 +78,14 @@ const custom_fakes = {
     )}`
   },
   alpha(count) {
-    let wholeString = ""
+    let wholeString = ''
     for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.ALPHABET)
     }
     return wholeString
   },
   numeric(count) {
-    let wholeString = ""
+    let wholeString = ''
     for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.NUMBERS)
     }
@@ -115,7 +107,7 @@ const TRAVEL_MODE = Object.freeze({
   VEHICLE: 1,
   FLIGHT: 2,
 })
-const DESTINATIONS = Object.freeze([...YUKON_COMMUNITIES, "Outside Yukon"])
+const DESTINATIONS = Object.freeze([...YUKON_COMMUNITIES, 'Outside Yukon'])
 const OUTSIDE_YUKON = DESTINATIONS.length
 
 const travellerIdentifier = faker.random.objectElement(TRAVELLER_IDENTIFIERS)
@@ -124,66 +116,66 @@ const travelMode = faker.random.objectElement(TRAVEL_MODE)
 const destination = faker.random.arrayElement(DESTINATIONS)
 
 const submission = {
-  traveller_identifier: travellerIdentifier,
-  traveller_name: custom_fakes.fullName(),
-  traveller_address: custom_fakes.yukonAddress(),
-  traveller_phone: custom_fakes.yukonPhoneNumber(),
-  traveller_purpose: faker.random.number({ min: 1, max: 5 }),
-  support_entrydocument: faker.random.arrayElement(SUPPORT_ENTRY_DOCUMENTS),
-  outside_canada: faker.random.number({ min: 1, max: 2 }),
-  locations_visited_14_days: faker.random.arrayElement([
+  'traveller.Identifier': travellerIdentifier,
+  'traveller.name': custom_fakes.fullName(),
+  'traveller.Address': custom_fakes.yukonAddress(),
+  'traveller.telephone': custom_fakes.yukonPhoneNumber(),
+  'entry.purpose': faker.random.number({ min: 1, max: 5 }),
+  'support.entrydocument': faker.random.arrayElement(SUPPORT_ENTRY_DOCUMENTS),
+  'outside.canada': faker.random.number({ min: 1, max: 2 }),
+  'locations.visited14days': faker.random.arrayElement([
     faker.address.city(),
     faker.address.country(),
   ]),
-  non_residient_not_transit_plan:
+  'nonresident.nottransitPlan':
     travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
       ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
-      : "",
-  "non_resident.transit_plan":
+      : '',
+  'nonresident.transitPlan':
     travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
       ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
-      : "",
-  resident_yukon_declaration:
+      : '',
+  'resident.yukonDeclaration':
     travellerIdentifier === TRAVELLER_IDENTIFIERS.RESIDENT
       ? faker.random.number({ min: 1, max: 2 })
       : null,
-  covid_symptoms_yes_no: hasCovidSymtoms,
-  covid_symptoms:
+  'covid.SymptomYesNo': hasCovidSymtoms,
+  'covid.Symptoms':
     hasCovidSymtoms === HAS_COVID_SYMPTOMS.YES
       ? faker.random.number({ min: 1, max: 3 })
       : null,
-  non_resident_not_transit_declaration:
+  'nonresident.nottransitDeclaration':
     travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
       ? faker.random.number({ min: 1, max: 2 })
       : null,
-  non_resident_transit_declaration:
+  'nonresident.transitDeclaration':
     travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
       ? faker.random.number({ min: 1, max: 2 })
       : null,
-  point_of_entry_travel: faker.random.arrayElement(
+  'pointofentry.Travel': faker.random.arrayElement(
     POINTS_OF_ENTRY.map((_, index) => index + 1)
   ),
-  office_use_travel_mode: travelMode,
-  office_use_license_plate:
-    travelMode === TRAVEL_MODE.VEHICLE ? custom_fakes.yukonLicensePlate() : "",
-  office_use_airline:
+  'officeuse.travelMode': travelMode,
+  'officeuser.Licenseplate':
+    travelMode === TRAVEL_MODE.VEHICLE ? custom_fakes.yukonLicensePlate() : '',
+  'officeuser.Airline':
     travelMode === TRAVEL_MODE.FLIGHT
       ? faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
-      : "",
-  office_use_flight_number:
-    travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : "",
-  office_use_date_entry: faker.date.recent(90).toLocaleDateString(),
-  office_use_time_entry: faker.date.recent().toLocaleTimeString(),
-  destionation_dropdown: faker.random.arrayElement([
+      : '',
+  'officeuse.flightNumber':
+    travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : '',
+  'officeuse.Dateentry': faker.date.recent(90).toLocaleDateString(),
+  'officeuse.Timeentry': faker.date.recent().toLocaleTimeString(),
+  'destionation.structured': faker.random.arrayElement([
     ...YUKON_COMMUNITIES,
-    "Outside Yukon",
+    'Outside Yukon',
   ]),
-  destination_other:
+  'destination.other':
     destination === OUTSIDE_YUKON ? faker.address.city() : null,
-  office_use_id: faker.random.arrayElement(
+  'officeuse.ID': faker.random.arrayElement(
     IDENTIFICATION.map((_, index) => index + 1)
   ),
-  office_use_additional_remarks: faker.lorem.sentences(
+  'officeuse.additionalRemarks': faker.lorem.sentences(
     faker.random.number({ min: 0, max: 3 })
   ),
 }
@@ -191,3 +183,25 @@ const submission = {
 console.log(submission, null, 2)
 
 // post data via http or axios
+
+doc = `
+Usage:
+  generate-covid-submission [--date=<date>] [--destination=<destination]
+  generate-covid-submission -h | --help | --version
+`
+
+var arguments = docopt(doc, {
+  version: '0.0.1',
+})
+
+console.log(arguments)
+
+// use docopt for arg parsing
+// requires --date and --destination options
+// console.log(process.argv)
+
+const { PROOF_URL, PROOF_FORM_ID } = process.env
+
+// part of the curl command
+console.log('PROOF_URL', PROOF_URL)
+console.log('PROOF_FORM_ID', PROOF_FORM_ID)

--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
-const faker = require('faker')
+const faker = require('faker/locale/en_CA')
 
-console.log(process.argv)
+// use docopt for arg parsing
+// requires --date and --destination options
+// console.log(process.argv)
 
 const { PROOF_URL, PROOF_FORM_ID } = process.env
 
@@ -9,8 +11,124 @@ const { PROOF_URL, PROOF_FORM_ID } = process.env
 console.log('PROOF_URL', PROOF_URL)
 console.log('PROOF_FORM_ID', PROOF_FORM_ID)
 
-const submission = {
+const YUKON_COMMUNITIES = [
+  "Beaver Creek",
+  "Burwash Landing",
+  "Carcross and Tagish",
+  "Carmacks",
+  "Dawson City",
+  "Faro",
+  "Haines Junction",
+  "Mayo",
+  "Mount Lorne",
+  "Old Crow",
+  "Pelly Crossing",
+  "Ross River",
+  "Teslin",
+  "Watson Lake",
+  "Whitehorse",
+]
 
+SUPPORT_ENTRY_DOCUMENTS = [
+
+]
+
+const IDENTIFICATION = [
+  "Passport",
+  "Birth Certificate",
+  "Driver's License",
+  "Canadian military identification card",
+  "Government-issued identification card",
+  "Canadian citizenship card",
+  "Status card",
+]
+
+const POINTS_OF_ENTRY = [
+  "Whitehorse Airport",
+  "Alaska Hwy",
+  "Stewart Cassiar Hwy",
+  "Dempster Hwy",
+  "Dawson City Airport",
+  "Watson Lake Airport",
+  "Mayo Airport",
+  "Beaver Creek Airport",
+  "Burwash Landing Airport",
+  "Carcross Airport",
+  "Carmacks Airport",
+  "Faro Airport",
+  "Haines Junction Airport",
+  "Old Crow Airport",
+  "Pelly Crossing Airport",
+  "Ross River Airport",
+  "Teslin Airport",
+]
+
+const DESTINATIONS =
+
+const AIRLINES_TO_THE_YUKON = ["Air North", "Air Canada"]
+
+const custom_fakes = {
+  ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
+  NUMBERS: '0123456789'.split(''),
+  fullname () {
+    return `${faker.name.firstName()} ${faker.name.lastName()}`
+  },
+  yukon_address () {
+    return `${faker.address.streetAddress()}, ${faker.random.arrayElement(YUKON_COMMUNITIES)}, YT, ${faker.address.zipCode()}`
+  },
+  yukon_license_plate () {
+    return faker.random.alphaNumeric(5).toUpperCase()
+  },
+  yukon_phone_number () {
+    return faker.phone.phoneNumber("867-###-###")
+  },
+  flight_number () {
+    return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(faker.random.number({ min: 1, max: 4}))}`
+  },
+  alpha (count) {
+    let wholeString = ""
+    for(let i = 0; i < (count || 1); i++) {
+      wholeString += faker.random.arrayElement(custom_fakes.ALPHABET)
+    }
+    return wholeString
+  },
+  numeric (count) {
+    let wholeString = ""
+    for(let i = 0; i < (count || 1); i++) {
+      wholeString += faker.random.arrayElement(custom_fakes.NUMBERS)
+    }
+    return wholeString
+  },
+}
+
+
+const submission = {
+  traveller_identifier: faker.random.number({ min: 1, max: 3})
+  traveller_name: custom_fakes.full_name()
+  traveller_address: custom_fakes.yukon_address()
+  traveller_phone: custom_fakes.yukon_phone_number()
+  traveller_purpose: faker.random.number({ min: 1, max: 5})
+  support_entrydocument: faker.random.arrayElement(IDENTIFICATION)
+  outside_canada: faker.random.number({ min: 1, max: 2})
+  locations_visited_14_days: faker.random.arrayElement([faker.address.city(), faker.address.country()])
+  non_residient_not_transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
+  non_resident.transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
+  resident_yukon_declaration: faker.random.number({ min: 1, max: 2})
+  covid_symptoms_yes_no: faker.random.number({ min: 1, max: 2})
+  covid_symptoms: faker.random.number({ min: 1, max: 3})
+  non_resident_not_transit_declaration: faker.random.number({ min: 1, max: 2})
+  non_resident_transit_declaration: faker.random.number({ min: 1, max: 2})
+  point_of_entry_travel: faker.random.arrayElement(POINTS_OF_ENTRY.map((_, index) => index + 1))
+  office_use_travel_mode: faker.random.number({ min: 1, max: 2})
+  office_use_license_plate: custom_fakes.yukon_license_plate()
+  office_use_airline: faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
+  office_use_flight_number: custom_fakes.flight_number()
+  office_use_date_entry: faker.date.recent(90).toLocaleDateString()
+  office_use_time_entry: faker.date.recent().toLocaleTimeString()
+  destionation_dropdown: faker.random.arrayElement([...YUKON_COMMUNITIES, 'Outside Yukon'])
+  destination_other: faker.random.city()
+  office_use_id: faker.random.arrayElement(IDENTIFICATION.map((_, index) => index + 1))
+  office_use_additional_remarks: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
 }
 
 console.log(submission, null, 2)

--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -63,26 +63,24 @@ const POINTS_OF_ENTRY = [
   "Teslin Airport",
 ]
 
-const DESTINATIONS =
-
 const AIRLINES_TO_THE_YUKON = ["Air North", "Air Canada"]
 
 const custom_fakes = {
   ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
   NUMBERS: '0123456789'.split(''),
-  fullname () {
+  fullName () {
     return `${faker.name.firstName()} ${faker.name.lastName()}`
   },
-  yukon_address () {
+  yukonAddress () {
     return `${faker.address.streetAddress()}, ${faker.random.arrayElement(YUKON_COMMUNITIES)}, YT, ${faker.address.zipCode()}`
   },
-  yukon_license_plate () {
+  yukonLicensePlate () {
     return faker.random.alphaNumeric(5).toUpperCase()
   },
-  yukon_phone_number () {
+  yukonPhoneNumber () {
     return faker.phone.phoneNumber("867-###-###")
   },
-  flight_number () {
+  flightNumber () {
     return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(faker.random.number({ min: 1, max: 4}))}`
   },
   alpha (count) {
@@ -103,32 +101,32 @@ const custom_fakes = {
 
 
 const submission = {
-  traveller_identifier: faker.random.number({ min: 1, max: 3})
-  traveller_name: custom_fakes.full_name()
-  traveller_address: custom_fakes.yukon_address()
-  traveller_phone: custom_fakes.yukon_phone_number()
-  traveller_purpose: faker.random.number({ min: 1, max: 5})
-  support_entrydocument: faker.random.arrayElement(IDENTIFICATION)
-  outside_canada: faker.random.number({ min: 1, max: 2})
-  locations_visited_14_days: faker.random.arrayElement([faker.address.city(), faker.address.country()])
-  non_residient_not_transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
-  non_resident.transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
-  resident_yukon_declaration: faker.random.number({ min: 1, max: 2})
-  covid_symptoms_yes_no: faker.random.number({ min: 1, max: 2})
-  covid_symptoms: faker.random.number({ min: 1, max: 3})
-  non_resident_not_transit_declaration: faker.random.number({ min: 1, max: 2})
-  non_resident_transit_declaration: faker.random.number({ min: 1, max: 2})
-  point_of_entry_travel: faker.random.arrayElement(POINTS_OF_ENTRY.map((_, index) => index + 1))
-  office_use_travel_mode: faker.random.number({ min: 1, max: 2})
-  office_use_license_plate: custom_fakes.yukon_license_plate()
-  office_use_airline: faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
-  office_use_flight_number: custom_fakes.flight_number()
-  office_use_date_entry: faker.date.recent(90).toLocaleDateString()
-  office_use_time_entry: faker.date.recent().toLocaleTimeString()
-  destionation_dropdown: faker.random.arrayElement([...YUKON_COMMUNITIES, 'Outside Yukon'])
-  destination_other: faker.random.city()
-  office_use_id: faker.random.arrayElement(IDENTIFICATION.map((_, index) => index + 1))
-  office_use_additional_remarks: faker.lorem.sentences(faker.random.number({ min: 1, max: 3}))
+  traveller_identifier: faker.random.number({ min: 1, max: 3}),
+  traveller_name: custom_fakes.fullName(),
+  traveller_address: custom_fakes.yukonAddress(),
+  traveller_phone: custom_fakes.yukonPhoneNumber(),
+  traveller_purpose: faker.random.number({ min: 1, max: 5}),
+  support_entrydocument: '',
+  outside_canada: faker.random.number({ min: 1, max: 2}),
+  locations_visited_14_days: faker.random.arrayElement([faker.address.city(), faker.address.country()]),
+  non_residient_not_transit_plan: faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
+  'non_resident.transit_plan': faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
+  resident_yukon_declaration: faker.random.number({ min: 1, max: 2}),
+  covid_symptoms_yes_no: faker.random.number({ min: 1, max: 2}),
+  covid_symptoms: faker.random.number({ min: 1, max: 3}),
+  non_resident_not_transit_declaration: faker.random.number({ min: 1, max: 2}),
+  non_resident_transit_declaration: faker.random.number({ min: 1, max: 2}),
+  point_of_entry_travel: faker.random.arrayElement(POINTS_OF_ENTRY.map((_, index) => index + 1)),
+  office_use_travel_mode: faker.random.number({ min: 1, max: 2}),
+  office_use_license_plate: custom_fakes.yukonLicensePlate(),
+  office_use_airline: faker.random.arrayElement(AIRLINES_TO_THE_YUKON),
+  office_use_flight_number: custom_fakes.flightNumber(),
+  office_use_date_entry: faker.date.recent(90).toLocaleDateString(),
+  office_use_time_entry: faker.date.recent().toLocaleTimeString(),
+  destionation_dropdown: faker.random.arrayElement([...YUKON_COMMUNITIES, 'Outside Yukon']),
+  destination_other: faker.address.city(),
+  office_use_id: faker.random.arrayElement(IDENTIFICATION.map((_, index) => index + 1)),
+  office_use_additional_remarks: faker.lorem.sentences(faker.random.number({ min: 1, max: 3})),
 }
 
 console.log(submission, null, 2)

--- a/bin/generate-covid-submission
+++ b/bin/generate-covid-submission
@@ -2,6 +2,7 @@
 
 const { docopt } = require('docopt')
 const faker = require('faker/locale/en_CA')
+const http = require('http')
 
 const YUKON_COMMUNITIES = [
   'Beaver Creek',
@@ -186,8 +187,11 @@ console.log(submission, null, 2)
 
 doc = `
 Usage:
-  generate-covid-submission [--date=<date>] [--destination=<destination]
-  generate-covid-submission -h | --help | --version
+  generate-submission [--date=<date>] [--destination=<destination]
+  generate-submission -h | --help | --version
+
+Info:
+  preferred date format ISO Date  "2015-03-25" (The International Standard)
 `
 
 var arguments = docopt(doc, {
@@ -200,8 +204,26 @@ console.log(arguments)
 // requires --date and --destination options
 // console.log(process.argv)
 
-const { PROOF_URL, PROOF_FORM_ID } = process.env
+const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 
-// part of the curl command
-console.log('PROOF_URL', PROOF_URL)
-console.log('PROOF_FORM_ID', PROOF_FORM_ID)
+const options = {
+  hostname: PROOF_URL,
+  port: 3000,
+  path: `/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/submit`,
+  method: 'POST',
+}
+
+const req = http.request(options, res => {
+  console.log('statusCode:', res.statusCode)
+  // console.log('headers:', res.headers)
+
+  // res.on('data', d => {
+  //   process.stdout.write(d)
+  // })
+})
+
+req.on('error', e => {
+  console.error(e)
+})
+req.write(JSON.stringify(submission))
+req.end()

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -181,14 +181,12 @@ const submission = {
   ),
 }
 
-console.log(submission, null, 2)
-
 // post data via http or axios
 
 doc = `
 Usage:
   generate-submission [--date=<date>] [--destination=<destination]
-  generate-submission -h | --help | --version
+  generate-submission -h | --help | --version | --dry-run
 
 Info:
   preferred date format ISO Date  "2015-03-25" (The International Standard)
@@ -197,8 +195,6 @@ Info:
 var arguments = docopt(doc, {
   version: '0.0.1',
 })
-
-console.log(arguments)
 
 // use docopt for arg parsing
 // requires --date and --destination options
@@ -213,17 +209,20 @@ const options = {
   method: 'POST',
 }
 
-const req = http.request(options, res => {
-  console.log('statusCode:', res.statusCode)
-  // console.log('headers:', res.headers)
+if (arguments['--dry-run']) {
+  console.log('Dry run of `generate-submission')
+  console.log('arguments =', arguments)
+  console.log('env =', { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER })
+  console.log('submission =', submission)
+  console.log('options =', options)
+  process.exit()
+}
 
-  // res.on('data', d => {
-  //   process.stdout.write(d)
-  // })
+const request = http.request(options, response => {
+  console.log('statusCode:', response.statusCode)
 })
-
-req.on('error', e => {
+request.on('error', e => {
   console.error(e)
 })
-req.write(JSON.stringify(submission))
-req.end()
+request.write(JSON.stringify(submission))
+request.end()

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -4,6 +4,18 @@ const { docopt } = require('docopt')
 const faker = require('faker/locale/en_CA')
 const http = require('http')
 
+// command line usage
+doc = `
+Usage:
+  generate-submission [--days-ago=<numberOfDays>] [--destination=<destination>] [--dry-run]
+  generate-submission -h | --help | --version
+`
+
+var arguments = docopt(doc, {
+  version: '0.0.1',
+})
+
+// Constant packs.
 const YUKON_COMMUNITIES = [
   'Beaver Creek',
   'Burwash Landing',
@@ -56,6 +68,7 @@ const POINTS_OF_ENTRY = [
 
 const AIRLINES_TO_THE_YUKON = ['Air North', 'Air Canada']
 
+// Some extra fakes, mostly for Yukon specific things.
 const custom_fakes = {
   ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
   NUMBERS: '0123456789'.split(''),
@@ -114,7 +127,19 @@ const OUTSIDE_YUKON = DESTINATIONS.length
 const travellerIdentifier = faker.random.objectElement(TRAVELLER_IDENTIFIERS)
 const hasCovidSymtoms = faker.random.objectElement(HAS_COVID_SYMPTOMS)
 const travelMode = faker.random.objectElement(TRAVEL_MODE)
-const destination = faker.random.arrayElement(DESTINATIONS)
+const destination =
+  (arguments['--destination'] &&
+    DESTINATIONS[Number(arguments['--destination']) - 1]) ||
+  faker.random.arrayElement(DESTINATIONS)
+const initialDate = new Date()
+const dateOfEntry = (
+  (arguments['--days-ago'] &&
+    initialDate.setDate(
+      initialDate.getDate() - Number(arguments['--days-ago'])
+    ) &&
+    initialDate) ||
+  faker.date.recent(90)
+).toLocaleDateString()
 
 const submission = {
   'traveller.Identifier': travellerIdentifier,
@@ -165,12 +190,9 @@ const submission = {
       : '',
   'officeuse.flightNumber':
     travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : '',
-  'officeuse.Dateentry': faker.date.recent(90).toLocaleDateString(),
+  'officeuse.Dateentry': dateOfEntry,
   'officeuse.Timeentry': faker.date.recent().toLocaleTimeString(),
-  'destionation.structured': faker.random.arrayElement([
-    ...YUKON_COMMUNITIES,
-    'Outside Yukon',
-  ]),
+  'destionation.structured': destination,
   'destination.other':
     destination === OUTSIDE_YUKON ? faker.address.city() : null,
   'officeuse.ID': faker.random.arrayElement(
@@ -181,25 +203,7 @@ const submission = {
   ),
 }
 
-// post data via http or axios
-
-doc = `
-Usage:
-  generate-submission [--date=<date>] [--destination=<destination]
-  generate-submission -h | --help | --version | --dry-run
-
-Info:
-  preferred date format ISO Date  "2015-03-25" (The International Standard)
-`
-
-var arguments = docopt(doc, {
-  version: '0.0.1',
-})
-
-// use docopt for arg parsing
-// requires --date and --destination options
-// console.log(process.argv)
-
+// Send the data
 const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 
 const options = {

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -2,7 +2,13 @@
 
 const { docopt } = require('docopt')
 const faker = require('faker/locale/en_CA')
-const http = require('http')
+const path = require('path')
+
+const binDir = path.dirname(__filename)
+const { requester, protocol, hostname, port } = require(path.resolve(
+  binDir,
+  '../utils/helpers'
+))
 
 // command line usage
 doc = `
@@ -72,33 +78,33 @@ const AIRLINES_TO_THE_YUKON = ['Air North', 'Air Canada']
 const custom_fakes = {
   ALPHABET: 'abcdefghijklmnopqrstuvwxyz'.split(''),
   NUMBERS: '0123456789'.split(''),
-  fullName() {
+  fullName () {
     return `${faker.name.firstName()} ${faker.name.lastName()}`
   },
-  yukonAddress() {
+  yukonAddress () {
     return `${faker.address.streetAddress()}, ${faker.random.arrayElement(
       YUKON_COMMUNITIES
     )}, YT, ${faker.address.zipCode()}`
   },
-  yukonLicensePlate() {
+  yukonLicensePlate () {
     return faker.random.alphaNumeric(5).toUpperCase()
   },
-  yukonPhoneNumber() {
+  yukonPhoneNumber () {
     return faker.phone.phoneNumber('867-###-###')
   },
-  flightNumber() {
+  flightNumber () {
     return `${custom_fakes.alpha(2).toUpperCase()}${custom_fakes.numeric(
       faker.random.number({ min: 1, max: 4 })
     )}`
   },
-  alpha(count) {
+  alpha (count) {
     let wholeString = ''
     for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.ALPHABET)
     }
     return wholeString
   },
-  numeric(count) {
+  numeric (count) {
     let wholeString = ''
     for (let i = 0; i < (count || 1); i++) {
       wholeString += faker.random.arrayElement(custom_fakes.NUMBERS)
@@ -208,15 +214,16 @@ const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 
 const stringifiedSubmission = JSON.stringify(submission)
 const options = {
-  hostname: PROOF_URL,
-  port: 3000,
+  protocol,
+  port,
+  hostname,
   path: `/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/submit`,
   method: 'POST',
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(stringifiedSubmission),
-  }
+  },
 }
 
 if (arguments['--dry-run']) {
@@ -228,14 +235,14 @@ if (arguments['--dry-run']) {
   process.exit()
 }
 
-const request = http.request(options, response => {
+const request = requester.request(options, response => {
   console.log('statusCode:', response.statusCode)
   response.on('data', chunk => {
     console.log(`BODY: ${chunk}`)
   })
 })
-request.on('error', e => {
-  console.error(e)
+request.on('error', error => {
+  console.error(error)
 })
 request.write(stringifiedSubmission)
 request.end()

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -206,11 +206,17 @@ const submission = {
 // Send the data
 const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 
+const stringifiedSubmission = JSON.stringify(submission)
 const options = {
   hostname: PROOF_URL,
   port: 3000,
   path: `/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/submit`,
   method: 'POST',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(stringifiedSubmission),
+  }
 }
 
 if (arguments['--dry-run']) {
@@ -224,9 +230,12 @@ if (arguments['--dry-run']) {
 
 const request = http.request(options, response => {
   console.log('statusCode:', response.statusCode)
+  response.on('data', chunk => {
+    console.log(`BODY: ${chunk}`)
+  })
 })
 request.on('error', e => {
   console.error(e)
 })
-request.write(JSON.stringify(submission))
+request.write(stringifiedSubmission)
 request.end()

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -235,15 +235,44 @@ function sendSubmission (submission) {
     },
   }
 
-  const request = requester.request(options, response => {
-    console.log('statusCode:', response.statusCode)
-    response.on('data', chunk => {
-      console.log(`BODY: ${chunk}`)
+  const request = requester
+    .request(options, response => {
+      const { statusCode, headers } = response
+
+      let rawData = ''
+      response.on('data', chunk => {
+        rawData += chunk
+      })
+      response.on('end', () => {
+        let parsedData = {}
+        if (/application\/json/.test(headers['content-type'])) {
+          try {
+            parsedData = JSON.parse(rawData)
+          } catch (error) {
+            // nop
+          }
+        }
+        switch (statusCode) {
+          case 200:
+          case 201:
+            console.log('Created a submision')
+            console.log('parsedData =', parsedData)
+            break
+          case 409:
+            console.log('Conflict')
+            console.log('statusCode =', statusCode)
+            console.log('options =', options)
+            break
+          default:
+            console.log('Unknown Error')
+            console.log('statusCode =', statusCode)
+            console.log('rawData = ', rawData)
+        }
+      })
     })
-  })
-  request.on('error', error => {
-    console.error(error)
-  })
+    .on('error', error => {
+      console.error(error)
+    })
   request.write(stringifiedSubmission)
   request.end()
 }

--- a/bin/generate-submission
+++ b/bin/generate-submission
@@ -5,10 +5,13 @@ const faker = require('faker/locale/en_CA')
 const path = require('path')
 
 const binDir = path.dirname(__filename)
-const { requester, protocol, hostname, port } = require(path.resolve(
-  binDir,
-  '../utils/helpers'
-))
+const {
+  requester,
+  protocol,
+  hostname,
+  port,
+  loadProviderInfo,
+} = require(path.resolve(binDir, '../utils/helpers'))
 
 // command line usage
 doc = `
@@ -113,119 +116,139 @@ const custom_fakes = {
   },
 }
 
-// Conditional Form Logic Helpers
-const TRAVELLER_IDENTIFIERS = Object.freeze({
-  RESIDENT: 1,
-  NON_RESIDENT_NON_TRANSIT: 2,
-  NON_RESIDENT: 3,
-})
-const HAS_COVID_SYMPTOMS = Object.freeze({
-  YES: 1,
-  NO: 2,
-})
-const TRAVEL_MODE = Object.freeze({
-  VEHICLE: 1,
-  FLIGHT: 2,
-})
-const DESTINATIONS = Object.freeze([...YUKON_COMMUNITIES, 'Outside Yukon'])
-const OUTSIDE_YUKON = DESTINATIONS.length
+function generateSubmission () {
+  // Conditional Form Logic Helpers
+  const TRAVELLER_IDENTIFIERS = Object.freeze({
+    RESIDENT: 1,
+    NON_RESIDENT_NON_TRANSIT: 2,
+    NON_RESIDENT: 3,
+  })
+  const HAS_COVID_SYMPTOMS = Object.freeze({
+    YES: 1,
+    NO: 2,
+  })
+  const TRAVEL_MODE = Object.freeze({
+    VEHICLE: 1,
+    FLIGHT: 2,
+  })
+  const DESTINATIONS = Object.freeze([...YUKON_COMMUNITIES, 'Outside Yukon'])
+  const OUTSIDE_YUKON = DESTINATIONS.length
 
-const travellerIdentifier = faker.random.objectElement(TRAVELLER_IDENTIFIERS)
-const hasCovidSymtoms = faker.random.objectElement(HAS_COVID_SYMPTOMS)
-const travelMode = faker.random.objectElement(TRAVEL_MODE)
-const destination =
-  (arguments['--destination'] &&
-    DESTINATIONS[Number(arguments['--destination']) - 1]) ||
-  faker.random.arrayElement(DESTINATIONS)
-const initialDate = new Date()
-const dateOfEntry = (
-  (arguments['--days-ago'] &&
-    initialDate.setDate(
-      initialDate.getDate() - Number(arguments['--days-ago'])
-    ) &&
-    initialDate) ||
-  faker.date.recent(90)
-).toLocaleDateString()
+  const travellerIdentifier = faker.random.objectElement(TRAVELLER_IDENTIFIERS)
+  const hasCovidSymtoms = faker.random.objectElement(HAS_COVID_SYMPTOMS)
+  const travelMode = faker.random.objectElement(TRAVEL_MODE)
+  const destination =
+    (arguments['--destination'] &&
+      DESTINATIONS[Number(arguments['--destination']) - 1]) ||
+    faker.random.arrayElement(DESTINATIONS)
+  const initialDate = new Date()
+  const dateOfEntry = (
+    (arguments['--days-ago'] &&
+      initialDate.setDate(
+        initialDate.getDate() - Number(arguments['--days-ago'])
+      ) &&
+      initialDate) ||
+    faker.date.recent(90)
+  ).toLocaleDateString()
 
-const submission = {
-  'traveller.Identifier': travellerIdentifier,
-  'traveller.name': custom_fakes.fullName(),
-  'traveller.Address': custom_fakes.yukonAddress(),
-  'traveller.telephone': custom_fakes.yukonPhoneNumber(),
-  'entry.purpose': faker.random.number({ min: 1, max: 5 }),
-  'support.entrydocument': faker.random.arrayElement(SUPPORT_ENTRY_DOCUMENTS),
-  'outside.canada': faker.random.number({ min: 1, max: 2 }),
-  'locations.visited14days': faker.random.arrayElement([
-    faker.address.city(),
-    faker.address.country(),
-  ]),
-  'nonresident.nottransitPlan':
-    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
-      ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
-      : '',
-  'nonresident.transitPlan':
-    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
-      ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
-      : '',
-  'resident.yukonDeclaration':
-    travellerIdentifier === TRAVELLER_IDENTIFIERS.RESIDENT
-      ? faker.random.number({ min: 1, max: 2 })
-      : null,
-  'covid.SymptomYesNo': hasCovidSymtoms,
-  'covid.Symptoms':
-    hasCovidSymtoms === HAS_COVID_SYMPTOMS.YES
-      ? faker.random.number({ min: 1, max: 3 })
-      : null,
-  'nonresident.nottransitDeclaration':
-    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
-      ? faker.random.number({ min: 1, max: 2 })
-      : null,
-  'nonresident.transitDeclaration':
-    travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
-      ? faker.random.number({ min: 1, max: 2 })
-      : null,
-  'pointofentry.Travel': faker.random.arrayElement(
-    POINTS_OF_ENTRY.map((_, index) => index + 1)
-  ),
-  'officeuse.travelMode': travelMode,
-  'officeuser.Licenseplate':
-    travelMode === TRAVEL_MODE.VEHICLE ? custom_fakes.yukonLicensePlate() : '',
-  'officeuser.Airline':
-    travelMode === TRAVEL_MODE.FLIGHT
-      ? faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
-      : '',
-  'officeuse.flightNumber':
-    travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : '',
-  'officeuse.Dateentry': dateOfEntry,
-  'officeuse.Timeentry': faker.date.recent().toLocaleTimeString(),
-  'destionation.structured': destination,
-  'destination.other':
-    destination === OUTSIDE_YUKON ? faker.address.city() : null,
-  'officeuse.ID': faker.random.arrayElement(
-    IDENTIFICATION.map((_, index) => index + 1)
-  ),
-  'officeuse.additionalRemarks': faker.lorem.sentences(
-    faker.random.number({ min: 0, max: 3 })
-  ),
+  return {
+    'traveller.Identifier': travellerIdentifier,
+    'traveller.name': custom_fakes.fullName(),
+    'traveller.Address': custom_fakes.yukonAddress(),
+    'traveller.telephone': custom_fakes.yukonPhoneNumber(),
+    'entry.purpose': faker.random.number({ min: 1, max: 5 }),
+    'support.entrydocument': faker.random.arrayElement(SUPPORT_ENTRY_DOCUMENTS),
+    'outside.canada': faker.random.number({ min: 1, max: 2 }),
+    'locations.visited14days': faker.random.arrayElement([
+      faker.address.city(),
+      faker.address.country(),
+    ]),
+    'nonresident.nottransitPlan':
+      travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
+        ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
+        : '',
+    'nonresident.transitPlan':
+      travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
+        ? faker.lorem.sentences(faker.random.number({ min: 1, max: 3 }))
+        : '',
+    'resident.yukonDeclaration':
+      travellerIdentifier === TRAVELLER_IDENTIFIERS.RESIDENT
+        ? faker.random.number({ min: 1, max: 2 })
+        : null,
+    'covid.SymptomYesNo': hasCovidSymtoms,
+    'covid.Symptoms':
+      hasCovidSymtoms === HAS_COVID_SYMPTOMS.YES
+        ? faker.random.number({ min: 1, max: 3 })
+        : null,
+    'nonresident.nottransitDeclaration':
+      travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT_NON_TRANSIT
+        ? faker.random.number({ min: 1, max: 2 })
+        : null,
+    'nonresident.transitDeclaration':
+      travellerIdentifier === TRAVELLER_IDENTIFIERS.NON_RESIDENT
+        ? faker.random.number({ min: 1, max: 2 })
+        : null,
+    'pointofentry.Travel': faker.random.arrayElement(
+      POINTS_OF_ENTRY.map((_, index) => index + 1)
+    ),
+    'officeuse.travelMode': travelMode,
+    'officeuser.Licenseplate':
+      travelMode === TRAVEL_MODE.VEHICLE
+        ? custom_fakes.yukonLicensePlate()
+        : '',
+    'officeuser.Airline':
+      travelMode === TRAVEL_MODE.FLIGHT
+        ? faker.random.arrayElement(AIRLINES_TO_THE_YUKON)
+        : '',
+    'officeuse.flightNumber':
+      travelMode === TRAVEL_MODE.FLIGHT ? custom_fakes.flightNumber() : '',
+    'officeuse.Dateentry': dateOfEntry,
+    'officeuse.Timeentry': faker.date.recent().toLocaleTimeString(),
+    'destionation.structured': destination,
+    'destination.other':
+      destination === OUTSIDE_YUKON ? faker.address.city() : null,
+    'officeuse.ID': faker.random.arrayElement(
+      IDENTIFICATION.map((_, index) => index + 1)
+    ),
+    'officeuse.additionalRemarks': faker.lorem.sentences(
+      faker.random.number({ min: 0, max: 3 })
+    ),
+  }
 }
 
 // Send the data
-const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 
-const stringifiedSubmission = JSON.stringify(submission)
-const options = {
-  protocol,
-  port,
-  hostname,
-  path: `/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/submit`,
-  method: 'POST',
-  headers: {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(stringifiedSubmission),
-  },
+function sendSubmission (submission) {
+  const { provider: formProvider, id: formId } = loadProviderInfo()
+
+  const stringifiedSubmission = JSON.stringify(submission)
+  const options = {
+    protocol,
+    port,
+    hostname,
+    path: `/forms/${formProvider}/${formId}/submit`,
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(stringifiedSubmission),
+    },
+  }
+
+  const request = requester.request(options, response => {
+    console.log('statusCode:', response.statusCode)
+    response.on('data', chunk => {
+      console.log(`BODY: ${chunk}`)
+    })
+  })
+  request.on('error', error => {
+    console.error(error)
+  })
+  request.write(stringifiedSubmission)
+  request.end()
 }
 
+const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 if (arguments['--dry-run']) {
   console.log('Dry run of `generate-submission')
   console.log('arguments =', arguments)
@@ -235,14 +258,5 @@ if (arguments['--dry-run']) {
   process.exit()
 }
 
-const request = requester.request(options, response => {
-  console.log('statusCode:', response.statusCode)
-  response.on('data', chunk => {
-    console.log(`BODY: ${chunk}`)
-  })
-})
-request.on('error', error => {
-  console.error(error)
-})
-request.write(stringifiedSubmission)
-request.end()
+const submission = generateSubmission()
+sendSubmission(submission)


### PR DESCRIPTION
### Overview
Write a script (should be node.js - could start with `#!/usr/bin/env node` to make it a stand-alone binary), that 
- takes `PROOF_URL` and `PROOF_FORM_ID` from the environment
- simulates a submission to that form by a user with some random data
- allows the submission date to be set by the caller (say a `--date` option)
- allows the destination field to be set by the caller (say `--destination`)

### Testing Instructions
1. Boot up the local app (core-app -> dev boot)
2. Set up an `.envrc` file with:
```bash
export PROOF_URL=http://localhost:3000
export PROOF_API_TOKEN=PROOF_API_TOKEN
export PROOF_FORM_ID=5
```
3. Try some submission options
- `bin/generate-submission --dry-run`
- `bin/generate-submission --destination=4 --days-ago=31 --dry-run`
- `bin/generate-submission --destination=4 --days-ago=31`
