### PR TITLE
EV-1295: Setup Form Binary

### DIFF
--- a/bin/setup-form
+++ b/bin/setup-form
@@ -17,56 +17,148 @@ var arguments = docopt(doc, {
   version: '0.0.1',
 })
 
+// load environment variables
+const binDir = path.dirname(__filename)
+const providerInfoPath = path.resolve(binDir, '../provider_info.yaml')
+const {
+  PROOF_URL,
+  PROOF_FORM_ID,
+  PROOF_FORM_PROVIDER,
+  PROOF_FORM_PROVIDER_ID,
+  PROOF_API_TOKEN,
+} = process.env
+
+// Create form config
+function createFormConfig () {
+  function loadProviderInfo () {
+    let providerInfo
+    try {
+      providerInfo = yaml.safeLoad(fs.readFileSync(providerInfoPath, 'utf8'))
+    } catch (error) {
+      providerInfo = {}
+    }
+
+    return {
+      provider: PROOF_FORM_PROVIDER || providerInfo.provider || 'proof',
+      providerIdentifier:
+        PROOF_FORM_PROVIDER_ID ||
+        providerInfo.providerIdentifier ||
+        `proof/form-example/${Date.now()}`,
+    }
+  }
+
+  function saveProviderInfo ({ provider, providerIdentifier }) {
+    try {
+      fs.readFileSync(
+        providerInfoPath,
+        yaml.safeDump({ provider, providerIdentifier }),
+        'utf8'
+      )
+    } catch (error) {
+      console.log('error =', error)
+    }
+  }
+
+  const data = JSON.stringify(loadProviderInfo())
+  const options = {
+    hostname: PROOF_URL,
+    port: 3000,
+    path: '/api/form_configs',
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${PROOF_API_TOKEN}`,
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data),
+    },
+  }
+
+  const request = http.request(options, response => {
+    console.log('statusCode:', response.statusCode)
+    let json_body = ''
+    response.on('data', chunk => {
+      json_body += chunk
+      if (response.statusCode === 422) return
+
+      console.log(`BODY: ${chunk}`)
+    })
+    response.on('end', () => {
+      body = JSON.parse(json_body)
+      switch (response.statusCode) {
+        case 201:
+          saveProviderInfo(body)
+          break
+        case 422:
+          console.log('options =', options)
+          console.log('data =', JSON.parse(data))
+          console.log('error =', body.errors)
+          // Hard exit on failure
+          process.exit(1)
+          break
+        default:
+          console.log('Created new config.')
+          console.log('body', body)
+      }
+    })
+  })
+  request.on('error', error => {
+    console.error(error)
+  })
+  request.write(data)
+  request.end()
+}
+
+function updateSchema (schema) {
+  // Send the data
+  const data = JSON.stringify({ schema })
+  const options = {
+    hostname: PROOF_URL,
+    port: 3000,
+    path: `/api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${PROOF_API_TOKEN}`,
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(data),
+    },
+  }
+  const request = http.request(options, response => {
+    console.log('statusCode:', response.statusCode)
+    response.on('data', chunk => {
+      console.log(`BODY: ${chunk}`)
+    })
+  })
+  request.on('error', error => {
+    console.error(error)
+  })
+  request.write(data)
+  request.end()
+}
+
 // Get document, or throw exception on error
 let schema
 try {
-  const binDir = path.dirname(__filename)
   const schemaPath = path.resolve(binDir, '../schema.yaml')
   schema = yaml.safeLoad(fs.readFileSync(schemaPath, 'utf8'))
 } catch (error) {
   console.log(error)
 }
 
-// Send the data
-const {
-  PROOF_URL,
-  PROOF_FORM_ID,
-  PROOF_FORM_PROVIDER,
-  PROOF_API_TOKEN,
-} = process.env
-
-const stringifiedSchema = JSON.stringify({ schema })
-const options = {
-  hostname: PROOF_URL,
-  port: 3000,
-  path: `/api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
-  method: 'POST',
-  headers: {
-    Accept: 'application/json',
-    Authorization: `Bearer ${PROOF_API_TOKEN}`,
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(stringifiedSchema),
-  },
-}
-
 if (arguments['--dry-run']) {
   const scriptName = path.basename(__filename)
   console.log(`Dry run of "bin/${scriptName}"\n`)
   console.log('arguments =', arguments)
-  console.log('env =', { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER })
+  console.log('env =', {
+    PROOF_URL,
+    PROOF_FORM_ID,
+    PROOF_FORM_PROVIDER,
+    PROOF_FORM_PROVIDER_ID,
+    PROOF_API_TOKEN,
+  })
   console.log('schema =', schema)
-  console.log('options =', options)
   process.exit()
 }
 
-const request = http.request(options, response => {
-  console.log('statusCode:', response.statusCode)
-  response.on('data', chunk => {
-    console.log(`BODY: ${chunk}`)
-  })
-})
-request.on('error', error => {
-  console.error(error)
-})
-request.write(stringifiedSchema)
-request.end()
+createFormConfig()
+// updateSchema(schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -33,7 +33,7 @@ const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
 const options = {
   hostname: PROOF_URL,
   port: 3000,
-  path: `api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
+  path: `/api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
   method: 'POST',
 }
 

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -5,10 +5,12 @@ const path = require('path')
 const url = require('url')
 
 const binDir = path.dirname(__filename)
-const { loadProviderInfo, saveProviderInfo, loadSchema } = require(path.resolve(
-  binDir,
-  '../utils/helpers'
-))
+const {
+  loadProviderInfo,
+  saveProviderInfo,
+  loadSchema,
+  requester,
+} = require(path.resolve(binDir, '../utils/helpers'))
 
 // command line usage
 doc = `
@@ -107,8 +109,9 @@ function updateSchema ({ protocol, hostname, port }, apiToken, schema) {
       'Content-Length': Buffer.byteLength(data),
     },
   }
-  const request = requester.request(options, response => {
-    const { statusCode } = response
+  const request = requester
+    .request(options, response => {
+      const { statusCode } = response
 
       let rawData = ''
       response.on('data', chunk => {
@@ -143,10 +146,11 @@ function updateSchema ({ protocol, hostname, port }, apiToken, schema) {
             console.log('rawData = ', rawData)
         }
       })
-  }).on('error', error => {
-    console.error(error)
-    process.exit(1)
-  })
+    })
+    .on('error', error => {
+      console.error(error)
+      process.exit(1)
+    })
   request.write(data)
   request.end()
 }
@@ -179,7 +183,5 @@ if (arguments['--dry-run']) {
 }
 
 const { protocol, hostname, port } = url.parse(PROOF_URL)
-const requester = protocol === 'https:' ? require('https') : require('http')
-
 createFormConfig({ protocol, hostname, port }, PROOF_API_TOKEN)
 updateSchema({ protocol, hostname, port }, PROOF_API_TOKEN, schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+const { docopt } = require('docopt')
+const fs = require('fs')
+const http = require('http')
+var path = require('path')
+const yaml = require('js-yaml')
+
+// command line usage
+doc = `
+Usage:
+  setup-form [--dry-run]
+  setup-form -h | --help | --version
+`
+
+var arguments = docopt(doc, {
+  version: '0.0.1',
+})
+
+// Get document, or throw exception on error
+let schema
+try {
+  const binDir = path.dirname(__filename)
+  const schemaPath = path.resolve(binDir, '../schema.yaml')
+  schema = yaml.safeLoad(fs.readFileSync(schemaPath, 'utf8'))
+} catch (error) {
+  console.log(error)
+}
+
+// Send the data
+const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
+
+const options = {
+  hostname: PROOF_URL,
+  port: 3000,
+  path: `api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
+  method: 'POST',
+}
+
+if (arguments['--dry-run']) {
+  const scriptName = path.basename(__filename)
+  console.log(`Dry run of "bin/${scriptName}"\n`)
+  console.log('arguments =', arguments)
+  console.log('env =', { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER })
+  console.log('schema =', schema)
+  process.exit()
+}
+
+const request = http.request(options, response => {
+  console.log('statusCode:', response.statusCode)
+})
+request.on('error', error => {
+  console.error(error)
+})
+request.write(JSON.stringify(schema))
+request.end()

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -22,64 +22,70 @@ var arguments = docopt(doc, {
 })
 
 // Create form config
-function createFormConfig () {
-  const { formProvider, provider, id } = loadProviderInfo()
+function createFormConfig (hostname, apiToken) {
+  const { providerIdentifier, provider, id } = loadProviderInfo()
 
   if (id) {
-    console.log(`Form Config exists using id: ${id}`)
+    console.log(`Provider info loaded, and form config id of "${id}" found.`)
     return
   }
 
-  const data = JSON.stringify({ formProvider, provider })
+  const data = JSON.stringify({ providerIdentifier, provider })
   const options = {
-    hostname: PROOF_URL,
+    hostname,
     port: 3000,
     path: '/api/form_configs',
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${PROOF_API_TOKEN}`,
+      Authorization: `Bearer ${apiToken}`,
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(data),
     },
   }
 
-  const request = http.request(options, response => {
-    let json_body = ''
-    response.on('data', chunk => {
-      json_body += chunk
-    })
-    response.on('end', () => {
-      if (/application\/json/.test(response.headers['content-type'])) {
-        body = JSON.parse(json_body)
-      } else {
-        console.log('content-type = ', response.headers['content-type'])
-      }
-      switch (response.statusCode) {
-        case 200:
-        case 201:
-          saveProviderInfo(body)
-          break
-        case 422:
-          console.log('Unprocessable Entity')
+  const request = http
+    .request(options, response => {
+      const { statusCode } = response
+
+      let rawData = ''
+      response.on('data', chunk => {
+        rawData += chunk
+      })
+      response.on('end', () => {
+        let parsedData = {}
+        try {
+          parsedData = JSON.parse(rawData)
+        } catch (error) {
+          console.log('JSON Parsing Error')
           console.log('statusCode =', response.statusCode)
-          console.log('options =', options)
-          console.log('data =', JSON.parse(data))
-          console.log('error =', body.errors)
-          // Hard exit on failure
-          process.exit(1)
-          break
-        default:
-          console.log('Unknown Error')
-          console.log('statusCode =', response.statusCode)
-          console.log('body = ', json_body)
-          process.exit(1)
-      }
+          console.log('rawData = ', rawData)
+          return
+        }
+        switch (statusCode) {
+          case 200:
+          case 201:
+            console.log('Saving Provider Info ...')
+            saveProviderInfo(parsedData)
+            break
+          case 422:
+            console.log('Unprocessable Entity')
+            console.log('statusCode =', response.statusCode)
+            console.log('options =', options)
+            console.log('data =', data)
+            console.log('error =', parsedData.errors)
+            break
+          default:
+            console.log('Unknown Error')
+            console.log('statusCode =', response.statusCode)
+            console.log('rawData = ', rawData)
+        }
+      })
     })
-  })
-  request.on('error', error => {
-    console.error(error)
-  })
+    .on('error', error => {
+      console.error(error)
+      process.exit(1)
+    })
   request.write(data)
   request.end()
 }
@@ -140,5 +146,5 @@ if (arguments['--dry-run']) {
   process.exit()
 }
 
-createFormConfig()
+createFormConfig(PROOF_URL, PROOF_API_TOKEN)
 updateSchema(schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -2,7 +2,6 @@
 
 const { docopt } = require('docopt')
 const path = require('path')
-const url = require('url')
 
 const binDir = path.dirname(__filename)
 const {

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -5,6 +5,8 @@ const fs = require('fs')
 const http = require('http')
 var path = require('path')
 const yaml = require('js-yaml')
+const binDir = path.dirname(__filename)
+const { loadProviderInfo, saveProviderInfo } = require(path.resolve(binDir, '../utils/helpers'))
 
 // command line usage
 doc = `
@@ -18,8 +20,6 @@ var arguments = docopt(doc, {
 })
 
 // load environment variables
-const binDir = path.dirname(__filename)
-const providerInfoPath = path.resolve(binDir, '../provider_info.yaml')
 const {
   PROOF_URL,
   PROOF_FORM_ID,
@@ -30,35 +30,6 @@ const {
 
 // Create form config
 function createFormConfig () {
-  function loadProviderInfo () {
-    let providerInfo
-    try {
-      providerInfo = yaml.safeLoad(fs.readFileSync(providerInfoPath, 'utf8'))
-    } catch (error) {
-      providerInfo = {}
-    }
-
-    return {
-      provider: PROOF_FORM_PROVIDER || providerInfo.provider || 'proof',
-      providerIdentifier:
-        PROOF_FORM_PROVIDER_ID ||
-        providerInfo.providerIdentifier ||
-        `proof/form-example/${Date.now()}`,
-    }
-  }
-
-  function saveProviderInfo ({ provider, providerIdentifier }) {
-    try {
-      fs.readFileSync(
-        providerInfoPath,
-        yaml.safeDump({ provider, providerIdentifier }),
-        'utf8'
-      )
-    } catch (error) {
-      console.log('error =', error)
-    }
-  }
-
   const data = JSON.stringify(loadProviderInfo())
   const options = {
     hostname: PROOF_URL,
@@ -74,21 +45,20 @@ function createFormConfig () {
   }
 
   const request = http.request(options, response => {
-    console.log('statusCode:', response.statusCode)
     let json_body = ''
     response.on('data', chunk => {
       json_body += chunk
-      if (response.statusCode === 422) return
-
-      console.log(`BODY: ${chunk}`)
     })
     response.on('end', () => {
       body = JSON.parse(json_body)
       switch (response.statusCode) {
+        case 200:
         case 201:
           saveProviderInfo(body)
           break
         case 422:
+          console.log('Unprocessable Entity')
+          console.log('statusCode =', response.statusCode)
           console.log('options =', options)
           console.log('data =', JSON.parse(data))
           console.log('error =', body.errors)
@@ -96,8 +66,10 @@ function createFormConfig () {
           process.exit(1)
           break
         default:
-          console.log('Created new config.')
-          console.log('body', body)
+          console.log('Unknown Error')
+          console.log('statusCode =', response.statusCode)
+          console.log('body = ', json_body)
+          process.exit()
       }
     })
   })

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -28,13 +28,25 @@ try {
 }
 
 // Send the data
-const { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER } = process.env
+const {
+  PROOF_URL,
+  PROOF_FORM_ID,
+  PROOF_FORM_PROVIDER,
+  PROOF_API_TOKEN,
+} = process.env
 
+const stringifiedSchema = JSON.stringify({ schema })
 const options = {
   hostname: PROOF_URL,
   port: 3000,
   path: `/api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
   method: 'POST',
+  headers: {
+    Accept: 'application/json',
+    Authorization: `Bearer ${PROOF_API_TOKEN}`,
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(stringifiedSchema),
+  },
 }
 
 if (arguments['--dry-run']) {
@@ -43,14 +55,18 @@ if (arguments['--dry-run']) {
   console.log('arguments =', arguments)
   console.log('env =', { PROOF_URL, PROOF_FORM_ID, PROOF_FORM_PROVIDER })
   console.log('schema =', schema)
+  console.log('options =', options)
   process.exit()
 }
 
 const request = http.request(options, response => {
   console.log('statusCode:', response.statusCode)
+  response.on('data', chunk => {
+    console.log(`BODY: ${chunk}`)
+  })
 })
 request.on('error', error => {
   console.error(error)
 })
-request.write(JSON.stringify(schema))
+request.write(stringifiedSchema)
 request.end()

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -9,6 +9,9 @@ const {
   saveProviderInfo,
   loadSchema,
   requester,
+  protocol,
+  hostname,
+  port,
 } = require(path.resolve(binDir, '../utils/helpers'))
 
 // command line usage
@@ -181,6 +184,5 @@ if (arguments['--dry-run']) {
   process.exit()
 }
 
-const { protocol, hostname, port } = url.parse(PROOF_URL)
 createFormConfig({ protocol, hostname, port }, PROOF_API_TOKEN)
 updateSchema({ protocol, hostname, port }, PROOF_API_TOKEN, schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -58,7 +58,7 @@ function createFormConfig (hostname, apiToken) {
           parsedData = JSON.parse(rawData)
         } catch (error) {
           console.log('JSON Parsing Error')
-          console.log('statusCode =', response.statusCode)
+          console.log('statusCode =', statusCode)
           console.log('rawData = ', rawData)
           return
         }
@@ -70,14 +70,14 @@ function createFormConfig (hostname, apiToken) {
             break
           case 422:
             console.log('Unprocessable Entity')
-            console.log('statusCode =', response.statusCode)
+            console.log('statusCode =', statusCode)
             console.log('options =', options)
             console.log('data =', data)
             console.log('error =', parsedData.errors)
             break
           default:
             console.log('Unknown Error')
-            console.log('statusCode =', response.statusCode)
+            console.log('statusCode =', statusCode)
             console.log('rawData = ', rawData)
         }
       })
@@ -90,30 +90,60 @@ function createFormConfig (hostname, apiToken) {
   request.end()
 }
 
-function updateSchema (schema) {
-  // Send the data
+function updateSchema (hostname, apiToken, schema) {
   const { provider: formProvider, id: formId } = loadProviderInfo()
   const data = JSON.stringify({ schema })
   const options = {
-    hostname: PROOF_URL,
+    hostname,
     port: 3000,
     path: `/api/forms/${formProvider}/${formId}/schemata`,
     method: 'POST',
     headers: {
       Accept: 'application/json',
-      Authorization: `Bearer ${PROOF_API_TOKEN}`,
+      Authorization: `Bearer ${apiToken}`,
       'Content-Type': 'application/json',
       'Content-Length': Buffer.byteLength(data),
     },
   }
   const request = http.request(options, response => {
-    console.log('statusCode:', response.statusCode)
-    response.on('data', chunk => {
-      console.log(`BODY: ${chunk}`)
-    })
-  })
-  request.on('error', error => {
+    const { statusCode } = response
+
+      let rawData = ''
+      response.on('data', chunk => {
+        rawData += chunk
+      })
+      response.on('end', () => {
+        let parsedData = {}
+        try {
+          parsedData = JSON.parse(rawData)
+        } catch (error) {
+          console.log('JSON Parsing Error')
+          console.log('statusCode =', statusCode)
+          console.log('rawData = ', rawData)
+          return
+        }
+        switch (statusCode) {
+          case 200:
+          case 201:
+            console.log('Updated Schema')
+            console.log('response =', parsedData)
+            break
+          case 422:
+            console.log('Unprocessable Entity')
+            console.log('statusCode =', statusCode)
+            console.log('options =', options)
+            console.log('data =', data)
+            console.log('error =', parsedData.errors)
+            break
+          default:
+            console.log('Unknown Error')
+            console.log('statusCode =', statusCode)
+            console.log('rawData = ', rawData)
+        }
+      })
+  }).on('error', error => {
     console.error(error)
+    process.exit(1)
   })
   request.write(data)
   request.end()
@@ -147,4 +177,4 @@ if (arguments['--dry-run']) {
 }
 
 createFormConfig(PROOF_URL, PROOF_API_TOKEN)
-updateSchema(schema)
+updateSchema(PROOF_URL, PROOF_API_TOKEN, schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 const { docopt } = require('docopt')
-const http = require('http')
-var path = require('path')
+const path = require('path')
+const url = require('url')
 
 const binDir = path.dirname(__filename)
 const { loadProviderInfo, saveProviderInfo, loadSchema } = require(path.resolve(
@@ -22,7 +22,7 @@ var arguments = docopt(doc, {
 })
 
 // Create form config
-function createFormConfig (hostname, apiToken) {
+function createFormConfig ({ protocol, hostname, port }, apiToken) {
   const { providerIdentifier, provider, id } = loadProviderInfo()
 
   if (id) {
@@ -32,8 +32,9 @@ function createFormConfig (hostname, apiToken) {
 
   const data = JSON.stringify({ providerIdentifier, provider })
   const options = {
+    protocol,
+    port,
     hostname,
-    port: 3000,
     path: '/api/form_configs',
     method: 'POST',
     headers: {
@@ -44,7 +45,7 @@ function createFormConfig (hostname, apiToken) {
     },
   }
 
-  const request = http
+  const request = requester
     .request(options, response => {
       const { statusCode } = response
 
@@ -90,12 +91,13 @@ function createFormConfig (hostname, apiToken) {
   request.end()
 }
 
-function updateSchema (hostname, apiToken, schema) {
+function updateSchema ({ protocol, hostname, port }, apiToken, schema) {
   const { provider: formProvider, id: formId } = loadProviderInfo()
   const data = JSON.stringify({ schema })
   const options = {
+    protocol,
+    port,
     hostname,
-    port: 3000,
     path: `/api/forms/${formProvider}/${formId}/schemata`,
     method: 'POST',
     headers: {
@@ -105,7 +107,7 @@ function updateSchema (hostname, apiToken, schema) {
       'Content-Length': Buffer.byteLength(data),
     },
   }
-  const request = http.request(options, response => {
+  const request = requester.request(options, response => {
     const { statusCode } = response
 
       let rawData = ''
@@ -176,5 +178,8 @@ if (arguments['--dry-run']) {
   process.exit()
 }
 
-createFormConfig(PROOF_URL, PROOF_API_TOKEN)
-updateSchema(PROOF_URL, PROOF_API_TOKEN, schema)
+const { protocol, hostname, port } = url.parse(PROOF_URL)
+const requester = protocol === 'https:' ? require('https') : require('http')
+
+createFormConfig({ protocol, hostname, port }, PROOF_API_TOKEN)
+updateSchema({ protocol, hostname, port }, PROOF_API_TOKEN, schema)

--- a/bin/setup-form
+++ b/bin/setup-form
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 const { docopt } = require('docopt')
-const fs = require('fs')
 const http = require('http')
 var path = require('path')
-const yaml = require('js-yaml')
+
 const binDir = path.dirname(__filename)
-const { loadProviderInfo, saveProviderInfo } = require(path.resolve(binDir, '../utils/helpers'))
+const { loadProviderInfo, saveProviderInfo, loadSchema } = require(path.resolve(
+  binDir,
+  '../utils/helpers'
+))
 
 // command line usage
 doc = `
@@ -19,18 +21,16 @@ var arguments = docopt(doc, {
   version: '0.0.1',
 })
 
-// load environment variables
-const {
-  PROOF_URL,
-  PROOF_FORM_ID,
-  PROOF_FORM_PROVIDER,
-  PROOF_FORM_PROVIDER_ID,
-  PROOF_API_TOKEN,
-} = process.env
-
 // Create form config
 function createFormConfig () {
-  const data = JSON.stringify(loadProviderInfo())
+  const { formProvider, provider, id } = loadProviderInfo()
+
+  if (id) {
+    console.log(`Form Config exists using id: ${id}`)
+    return
+  }
+
+  const data = JSON.stringify({ formProvider, provider })
   const options = {
     hostname: PROOF_URL,
     port: 3000,
@@ -50,7 +50,11 @@ function createFormConfig () {
       json_body += chunk
     })
     response.on('end', () => {
-      body = JSON.parse(json_body)
+      if (/application\/json/.test(response.headers['content-type'])) {
+        body = JSON.parse(json_body)
+      } else {
+        console.log('content-type = ', response.headers['content-type'])
+      }
       switch (response.statusCode) {
         case 200:
         case 201:
@@ -69,7 +73,7 @@ function createFormConfig () {
           console.log('Unknown Error')
           console.log('statusCode =', response.statusCode)
           console.log('body = ', json_body)
-          process.exit()
+          process.exit(1)
       }
     })
   })
@@ -82,11 +86,12 @@ function createFormConfig () {
 
 function updateSchema (schema) {
   // Send the data
+  const { provider: formProvider, id: formId } = loadProviderInfo()
   const data = JSON.stringify({ schema })
   const options = {
     hostname: PROOF_URL,
     port: 3000,
-    path: `/api/forms/${PROOF_FORM_PROVIDER}/${PROOF_FORM_ID}/schemata`,
+    path: `/api/forms/${formProvider}/${formId}/schemata`,
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -108,14 +113,16 @@ function updateSchema (schema) {
   request.end()
 }
 
-// Get document, or throw exception on error
-let schema
-try {
-  const schemaPath = path.resolve(binDir, '../schema.yaml')
-  schema = yaml.safeLoad(fs.readFileSync(schemaPath, 'utf8'))
-} catch (error) {
-  console.log(error)
-}
+// load environment variables
+const {
+  PROOF_URL,
+  PROOF_FORM_ID,
+  PROOF_FORM_PROVIDER,
+  PROOF_FORM_PROVIDER_ID,
+  PROOF_API_TOKEN,
+} = process.env
+
+const schema = loadSchema()
 
 if (arguments['--dry-run']) {
   const scriptName = path.basename(__filename)
@@ -128,9 +135,10 @@ if (arguments['--dry-run']) {
     PROOF_FORM_PROVIDER_ID,
     PROOF_API_TOKEN,
   })
+  console.log('providerInfo =', loadProviderInfo())
   console.log('schema =', schema)
   process.exit()
 }
 
 createFormConfig()
-// updateSchema(schema)
+updateSchema(schema)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Example Node App for Proof Form Query API",
   "main": "index.js",
   "scripts": {
+    "setup": "bin/setup-form",
     "server": "node index.js"
   },
   "repository": "git@github.com:proofgov/example-form-query-api.git",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "express": "^4.17.1"
+    "docopt": "^0.6.2",
+    "express": "^4.17.1",
+    "faker": "^4.1.0",
+    "js-yaml": "^3.14.0"
   }
 }

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,185 +1,1198 @@
-start:
-  '#type': wizard_page
-  '#title': Start
-  start_page_content:
-    '#type': markup
-    '#markup': |
-      This is an example form schema used in this example
-travellers_declaration_1:
-  '#type': section
-  '#title': 'Traveller's Declaration'
-  traveller_identifier:
-    '#type': select_other
-    '#options':
-      1: Resident of the Yukon
-      2: Non-Resident of the Yukon (Not for transit to Alaska or other parts of
-        Canada)
-      3: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-        of Canada)
-  traveller_name:
-    '#type': textfield
-    '#title': Name
-  traveller_address:
-    '#type': textfield
-    '#title': Address of your Residence (where you will be isolating yourself)
-  traveller_phone:
-    '#type': tel
-    '#title': Telephone Number (you must be available at this number)
-  traveller_purpose:
-    '#type': select_other
-    '#title': Purpose of Entry
-    '#options':
-      1: Travel to my place of residence in Yukon
-      2: Stay with a family member at their place of residence in Yukon
-      3: Provide critical or essential services in Yukon or in the BC-Yukon border area
-      4: Transit through Yukon as described in subsection 2(3) of the Health Order
-      5: Engage in activities described in the Traditional Activities Order
-  support_entrydocument:
-    '#type': textfield
-    '#title': Documentation to support your purpose for entering the Yukon
-  outside_canada:
-    '#type': radios
-    '#title': Have you been outside Canada in the last 14 days?
-    '#options':
-      1: Yes
-      2: No
-  locations_visited_14_days:
-    '#type': textfield
-    '#title': What locations have you visited in the last 14 days?
-  non_residient_not_transit_plan:
-    '#type': textfield
-    '#title': Isolation plan/Plan after 14 day isolation complete
-  non_resident.transit_plan:
-    '#type': textfield
-    '#title': Plan travelling through Yukon
-  resident_yukon_declaration:
-    '#type': radios
-    '#title': |
-      This information is true and correct. I am aware that if I am granted entry
-      to Yukon, the Chief Medical Officer of Health requires me to self-isolate for
-      14 days. If I am defined as an essential service, I must self-isolate for 14
-      days. If I am defined as a critical service, I am required to follow the direction
-      and guidelines for the delivery of critical services. I am also aware that I
-      must act in accordance with this declaration and any enforcement orders or health
-      emergency orders related to COVID-19.
-    '#options':
-      1: Agree
-      2: Disagree
-  covid_symptoms_yes_no:
-    '#type': radios
-    '#title': Do you have any COVID-19 symptoms?
-    '#options':
-      1: I have symptoms
-      2: No symptoms
-  covid_symptoms:
-    '#type': select_other
-    '#title': What symptoms are you experiencing?
-    '#options':
-      1: Cough
-      2: Fever
-      3: Difficulty breathing
-  non_resident_not_transit_declaration:
-    '#type': radios
-    '#title': |
-      This information is true and correct. I am aware that if I am granted entry
-      to Yukon, the Chief Medical Officer of Health requires me to self-isolate for
-      14 days. If I am defined as an essential service, I must self-isolate for 14
-      days. If I am defined as a critical service, I am required to follow the direction
-      and guidelines for the delivery of critical services. I am also aware that I
-      must act in accordance with this declaration and any enforcement orders or health
-      emergency orders related to COVID-19.
-    '#options':
-      1: Agree
-      2: Disagree
-  non_resident_transit_declaration:
-    '#type': radios
-    '#title': |
-      This information is true and correct. I am aware that the Civil Emergency
-      Measures Health Protection Order requires me to complete my transit of Yukon
-      within 24 hours of entry. Failure to comply with the Orders is punishable by
-      Law.
-    '#options':
-      1: Agree
-      2: Disagree
-travellers_declaration_2:
-  '#type': section
-  '#title': 'Traveller's Declaration'
-  point_of_entry_travel:
-    '#type': select_other
-    '#title': Point of Entry
-    '#options':
-      1: Whitehorse Airport
-      2: Alaska Hwy
-      3: Stewart Cassiar Hwy
-      4: Dempster Hwy
-      5: Dawson City Airport
-      6: Watson Lake Airport
-      7: Mayo Airport
-      8: Beaver Creek Airport
-      9: Burwash Landing Airport
-      10: Carcross Airport
-      11: Carmacks Airport
-      12: Faro Airport
-      13: Haines Junction Airport
-      14: Old Crow Airport
-      15: Pelly Crossing Airport
-      16: Ross River Airport
-      17: Teslin Airport
-  office_use_travel_mode:
-    '#type': select_other
-    '#title': Travel Mode
-    '#options':
-      1: Vehicle
-      2: Flight
-  office_use_license_plate:
-    '#type': textfield
-    '#title': License Plate
-  office_use_airline:
-    '#type': textfield
-    '#title': Airline
-  office_use_flight_number:
-    '#type': textfield
-    '#title': Flight Number/Registration Number
-  office_use_date_entry:
-    '#type': datelist
-    '#title': Date of Entry
-  office_use_time_entry:
-    '#type': textfield
-    '#title': Time of Entry (optional)
-  destionation_dropdown:
-    '#type': select_other
-    '#title': Destination
-    '#options':
-      1: Whitehorse
-      2: Beaver Creek
-      3: Burwash Landing
-      4: Carcross and Tagish
-      5: Carmacks
-      6: Dawson City
-      7: Faro
-      8: Haines Junction
-      9: Mayo
-      10: Mount Lorne
-      11: Old Crow
-      12: Pelly Crossing
-      13: Ross River
-      14: Teslin
-      15: Watson Lake
-      16: Outside Yukon
-  destination_other:
-    '#type': textfield
-    '#title': If destination is outside Yukon, please specify where
-  office_use_id:
-    '#type': select_other
-    '#title': Identification (provided to verify information on this form)
-    '#options':
-      1: Passport
-      2: Birth Certificate
-      3: Driver's License
-      4: Canadian military identification card
-      5: Government-issued identification card
-      6: Canadian citizenship card
-      7: Status card
-  office_use_additional_remarks:
-    '#type': textfield
-    '#title': Additional Remarks
+---
+customScripts: []
+deleted: false
+enableSectionsNavigator: false
+enableSidebar: false
+lastPublishDate: '2020-05-15T17:38:31.459Z'
+originalPublishDate: '2020-04-07T01:13:14.561Z'
+outputArtifacts: []
+pdfReferences: []
+publishStatus: PUBLISHED
+sections: []
+tags: []
+templateFormat: v1.3.9
+version:
+  label: 0.0.27
+  commitMessage: Fixing spelling mistake
+  author:
+    cuid: cjx0n8q49059l0qpjn76mdra9
+    emailAddress: ben@proofgov.com
+  created: '2020-05-15T17:38:31.037Z'
+  smartForm: cka8hjs3h000275ntmrydla3t
+  publishedOn: '2020-05-15T17:38:31.459Z'
+_id: 5ebed3975479080101f5eb48
+browserTitle:
+  en: Yukon Traveller Form
+favicon: https://static.formhero.io/formhero/fh-icon-200.png
+template:
+  languages:
+  - en
+  defaultLang: en
+  showLanguagesSelector: true
+navigation:
+  additionMsg: Press to Enter
+  back:
+    display: true
+    label: Back
+  continue:
+    display: always
+    label: Next
+  skip:
+    label: Not Applicable / Skip
+sidebar:
+  tiles: []
+timeoutConfig:
+  isActive: false
+  sessionDuration: 30
+  idleDuration: 15
+  warningMessage: Your session will expire
+  redirectUrl: https://formhero.com/
+realtimeSummary:
+  enabled: false
+  cols: auto
+  entries: []
+  hideEmpty: false
+  panelLinks: false
+catalogueConfig:
+  type: none
+title: Yukon Traveller Form v3
+organization: proofgov
+team: demos
+slug: yukon-traveller-form-v3
+decisionTree:
+  hasProgressBarCompletion: true
+  nodes:
+  - binding: FORMHERO.USER_LANG
+    buttonText:
+      en: Begin
+    noOkayGoBehaviour: true
+    type: startNode
+    uuid: 74187a6b-6a45-495c-bc6e-fdcb39b30fc7
+    preface:
+    - type: h1
+      text:
+        en: Traveller's Declaration
+      uuid: f2013102-78e5-4cf4-b7da-c839b5835758
+    - type: h3
+      useAsLabel: true
+      text:
+        en: Yukon Government
+      uuid: a24880bc-8d7d-46e0-a009-9a9a9aaddc69
+    level: 0
+    nodeLabel: START
+    subsequentPanelsBehavior: default
+    panelWrapperClasses: ''
+    panelClasses: panel-74187a6b-6a45-495c-bc6e-fdcb39b30fc7
+    displayToUser: false
+    prepopulation: []
+    actionTrigger:
+      type: button
+    postface: []
+  - nodeLabel: Traveller's Declaration
+    fields:
+    - label:
+        en: 'I identify as one of the following:'
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Resident of the Yukon
+        value: '1'
+      - label:
+          en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+            of Canada)
+        value: '2'
+      - label:
+          en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+            of Canada)
+        value: 3
+        uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      uuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+      type: multicheck
+      binding: traveller.Identifier
+      layoutSetting:
+        default:
+          rowHeight: 75
+          columns: 1
+      maximumSelections: 1
+    - label:
+        en: Name
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: true
+      uuid: 7476dcd4-e049-433b-a55b-2dc0ec90e16c
+      type: text
+      binding: traveller.name
+      validators: []
+      keyboard: text
+      conditional: true
+      conditions:
+      - uuid: 67f9e765-1508-4d54-a2e3-bc808a510071
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: 27e0feb5-5c32-4d53-97ec-a1295c384b2b
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: d7144566-c642-451f-b75f-9b2459435d53
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Address of your Residence (where you will be isolating yourself)
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: c35d1657-0c46-4612-aa31-bc45cd3dacf1
+      type: text
+      binding: traveller.Address
+      validators: []
+      keyboard: text
+      parentLayoutClasses:
+      - flex-100
+      conditional: true
+      conditions:
+      - uuid: a2b29940-cb9d-4389-a2fd-2fbae5820505
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: 489ac205-6abb-4544-8426-9e8b254562cc
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 27171042-b484-4e38-b779-4b0730f71638
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Telephone Number (you must be available at this number)
+      mask: "(999) 999-9999"
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: 624e1b2c-fbdd-44b7-b34f-4b4e9f74b241
+      type: text
+      binding: traveller.telephone
+      validators: []
+      keyboard: telephone
+      conditional: true
+      conditions:
+      - uuid: 82e479ff-0172-4d28-bdf2-3a05fb7a2236
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: 5ba7f9c9-d339-4f9e-9cd3-daca0ce22c8a
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 6654c9b1-ec70-4c4f-b3eb-3860c1fe054e
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+      useMask: true
+    - label:
+        en: Purpose of Entry
+      required: true
+      api:
+        enabled: false
+        clearOnRefresh: false
+      uuid: a21c1431-413e-49b7-802d-452d35cca403
+      type: dropdown
+      binding: entry.purpose
+      pickList:
+        en: '{"_id":"5e9a1ad481d44d993f7dc352","organization":"proofgov","team":"demos","titleSlug":"purpose-of-entry-covid-travel","cuid":"ck94oq3ku00cu0kntxfw0itx3","title":"Purpose
+          of Entry COVID Travel"}'
+      conditional: true
+      conditions:
+      - uuid: 11281366-64b2-4888-a848-c78801036daf
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: d4e59b3a-88e6-4928-ac30-0943113b7a48
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 5b5be06d-0888-41c8-b4dd-8e576aca6999
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+      hint:
+        en: ''
+    - label:
+        en: Documentation to support your purpose for entering the Yukon
+      maxlength:
+      minlength:
+      hint:
+      required: false
+      uuid: 3c8b73c3-2065-4f31-b3d5-cb2ae94895f6
+      type: long-text
+      binding: support.entrydocument
+      conditional: true
+      conditions:
+      - uuid: 0a91579e-2dfb-4187-8156-46c83f6315cb
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: f26dcd4b-a2ab-4bc9-9d13-394092bcd858
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 2e13f85a-210e-4b2e-b793-40f6f717390d
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Have you been outside Canada in the last 14 days?
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: 'Yes'
+        value: '1'
+      - label:
+          en: 'No'
+        value: '2'
+      uuid: 9d8b5185-1860-47e0-8b97-3bdae5a51747
+      type: multicheck
+      binding: outside.canada
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      maximumSelections: 1
+      conditional: true
+      conditions:
+      - uuid: 4c1b1bac-705a-4c6c-a6dd-e5c040fb3856
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: e1453121-67a9-4af6-af4e-b69b8dbe884c
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 5401d513-ca9f-47ed-96a6-2da27a81a35b
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: What locations have you visited in the last 14 days?
+      maxlength:
+      minlength:
+      hint:
+        en: All communities, provinces, territories and countries
+      required: false
+      uuid: ac02e24f-a223-4fbc-8805-b4c3fb84a03e
+      type: long-text
+      binding: locations.visited14days
+      conditional: true
+      conditions:
+      - uuid: 8d82c8df-64c3-40e9-b422-92b9e321c265
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: b312eccc-1da2-45e6-9430-87791e883892
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 633af525-8d2b-4992-b1b8-222d3fcbc8f5
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Isolation plan/Plan after 14 day isolation complete
+      maxlength:
+      minlength:
+      hint:
+      required: false
+      uuid: 9d7c5a4b-8056-441d-a6f5-f8cc09ab3b21
+      type: long-text
+      binding: nonresident.nottransitPlan
+      conditional: true
+      conditions:
+      - uuid: c6e81b80-03ce-4198-aa30-cece49cf85a3
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: Plan travelling through Yukon
+      maxlength:
+      minlength:
+      hint:
+        en: Include route, businesses you will visit, time and location of exit from
+          Yukon
+      required: false
+      uuid: 1ca7c8db-212f-485b-b122-6539c196db30
+      type: long-text
+      binding: nonresident.transitPlan
+      conditional: true
+      conditions:
+      - uuid: de5bd468-b1ad-4daa-9a21-6f491d9bbf67
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: This information is true and correct. I am aware that if I am granted
+          entry to Yukon, the Chief Medical Officer of Health requires me to self-isolate
+          for 14 days. If I am defined as an essential service, I must self-isolate
+          for 14 days. If I am defined as a critical service, I am required to follow
+          the direction and guidelines for the delivery of critical services. I am
+          also aware that I must act in accordance with this declaration and any enforcement
+          orders or health emergency orders related to COVID-19.
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Agree
+        value: '1'
+      - label:
+          en: Disagree
+        value: '2'
+      uuid: f3de75c3-5e75-4c24-8665-3942acb777b1
+      type: multicheck
+      binding: resident.yukonDeclaration
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      maximumSelections: 1
+      parentLayoutClasses:
+      - flex-100
+      conditional: true
+      conditions:
+      - uuid: 0bd6fed6-b7d9-4a15-b525-44301ba35db8
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: Do you have any COVID-19 symptoms?
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: I have symptoms
+        value: '1'
+      - label:
+          en: No symptoms
+        value: '2'
+      uuid: 37c8c52a-4b2b-4d34-a619-1e97b1d38f26
+      type: multicheck
+      binding: covid.SymptomYesNo
+      layoutSetting:
+        default:
+          rowHeight: 75
+          columns: 3
+      maximumSelections: 1
+      parentLayoutClasses:
+      - flex-100
+      conditional: true
+      conditions:
+      - uuid: 93af8dc7-199e-452a-8137-5ef34f78462c
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Resident of the Yukon
+          value: '1'
+      - uuid: bbac81cd-e471-4191-8f7a-fbfe81eeebaf
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      - uuid: 22e926b7-4ab4-4a21-a6a7-c839b081bebc
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: What symptoms are you experiencing?
+      hint:
+        en: Select all that apply
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Cough
+        value: '1'
+      - label:
+          en: Fever
+        value: '2'
+      - label:
+          en: Difficulty breathing
+        value: 3
+        uuid: a4915da1-b195-4721-83d8-a8ed9441660a
+      uuid: 5689b9d9-a75b-4995-b91f-e7140812ddf3
+      type: multicheck
+      binding: covid.Symptoms
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      info:
+        en: If you have any of these symptoms, call 811 on arrival at your residence.
+      maximumSelections: 3
+      conditional: true
+      conditions:
+      - uuid: 63be4419-36d7-45f7-83f0-805ae2845dab
+        controlVariable:
+          key: covid.SymptomYesNo
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 37c8c52a-4b2b-4d34-a619-1e97b1d38f26
+        operator: equal-to
+        expectedValue:
+          label:
+            en: I have symptoms
+          value: '1'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: This information is true and correct. I am aware that if I am granted
+          entry to Yukon, the Chief Medical Officer of Health requires me to self-isolate
+          for 14 days. If I am defined as an essential service, I must self-isolate
+          for 14 days. If I am defined as a critical service, I am required to follow
+          the direction and guidelines for the delivery of critical services. I am
+          also aware that I must act in accordance with this declaration and any enforcement
+          orders or health emergency orders related to COVID-19.
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Agree
+        value: '1'
+      - label:
+          en: Disagree
+        value: '2'
+      uuid: 2ca34cbc-0275-489b-9356-33500bce8382
+      type: multicheck
+      binding: nonresident.nottransitDeclaration
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      maximumSelections: 1
+      conditional: true
+      conditions:
+      - uuid: a83fa9c0-5f04-4ab9-8377-e70694457560
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
+              of Canada)
+          value: '2'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: This information is true and correct. I am aware that the Civil Emergency
+          Measures Health Protection Order requires me to complete my transit of Yukon
+          within 24 hours of entry. Failure to comply with the Orders is punishable
+          by Law.
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Agree
+        value: '1'
+      - label:
+          en: Disagree
+        value: '2'
+      uuid: 5e01da96-ce32-4599-b7e9-93b3ea0d1bb7
+      type: multicheck
+      binding: nonresident.transitDeclaration
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      maximumSelections: 1
+      conditional: true
+      conditions:
+      - uuid: 5d9b786b-6cd9-4944-8853-973416b2a112
+        controlVariable:
+          key: traveller.Identifier
+          type: multicheck
+          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+              of Canada)
+          value: 3
+          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    label-position: top
+    type: formNode
+    uuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+    preface:
+    - type: h1
+      text:
+        en: Traveller's Declaration
+      uuid: 3c1f070e-26e2-40e9-9c76-ecb214b13130
+      useAsLabel: true
+    subsequentPanelsBehavior: default
+    panelWrapperClasses: ''
+    panelClasses: panel-582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+    canSkipText: Not Applicable / Skip
+    postface: []
+    useOnChangeJavaScript: true
+    customOnChangeJavaScript: "function onDataChange(immutableData, callback) {\r\n
+      \   //Add values to updatedData to modify the map of collected data.\r\n    //
+      \   Example: updatedData['applicant.givenName'] = 'Ryan'; would set the variable
+      'applicant.givenName' to 'Ryan'\r\n    var updatedData = {};\r\n    //Your Custom
+      Code Starts Here\r\n    function formatDate(date) {\r\n        dateToFormat
+      = new Date(date);\r\n        mm = (\"0\" + ((new Date(date).getMonth() + 1))).slice(-2);\r\n
+      \       dd = (\"0\" + (new Date(date).getDate())).slice(-2);\r\n        yyyy
+      = new Date(date).getFullYear();\r\n        formattedDate = yyyy + \"-\" + mm
+      + \"-\" + dd;\r\n        return formattedDate\r\n    }\r\n\r\n    let today
+      \ = new Date();\r\n    updatedData['officeuse.Dateentry'] = formatDate(today);\r\n\r\n
+      \   //Your Custom Code Ends Here\r\n    callback(updatedData);\r\n}"
+  - nodeLabel: Traveller's Declaration
+    fields:
+    - label:
+        en: Point of Entry
+      required: true
+      api:
+        enabled: false
+        clearOnRefresh: false
+      uuid: 7b2eee87-0f8d-4384-a983-309d3c6f0729
+      type: dropdown
+      binding: pointofentry.Travel
+      pickList:
+        en: '{"_id":"5e9f46df81d44d993f31ad11","organization":"proofgov","team":"demos","titleSlug":"17-points-of-entry","cuid":"ck9aaj3hb00j30io1ynd9vl07","title":"17
+          Points of Entry"}'
+      conditional: false
+      conditions:
+      - uuid: '084d3efd-3806-462d-89e9-c1302af20b77'
+        controlVariable:
+          key: officeuse.travelMode
+          type: multicheck
+          nodeUuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
+          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Vehicle
+          value: '1'
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Travel Mode
+      hint:
+        en: ''
+      errorMessages:
+        selectionCount:
+          fail: We need you to pick more options.
+          pass: You've picked as many as we need you to.
+      minimumSelections: 1
+      options:
+      - label:
+          en: Vehicle
+        value: '1'
+      - label:
+          en: Flight
+        value: '2'
+      uuid: 8323173b-9f50-4f90-822a-d99c309f09f4
+      type: multicheck
+      binding: officeuse.travelMode
+      layoutSetting:
+        default:
+          rowHeight: 55
+          columns: 3
+      maximumSelections: 1
+      conditional: false
+      conditions:
+      - uuid: 7988d053-a1cf-4216-a91a-19ca58e3e552
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: License Plate
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: cf401498-671d-4572-9a01-062a1395997f
+      type: text
+      binding: officeuser.Licenseplate
+      validators: []
+      keyboard: text
+      conditional: true
+      conditions:
+      - uuid: b39c5f78-6c08-4924-abba-0b12f4d40fe5
+        controlVariable:
+          key: officeuse.travelMode
+          type: multicheck
+          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
+          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Car
+          value: '1'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: Airline
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: e434d84a-6907-4551-80e6-1967a177a055
+      type: text
+      binding: officeuser.Airline
+      validators: []
+      keyboard: text
+      conditional: true
+      conditions:
+      - uuid: 19a4fa14-2c77-4a52-bd34-f403c34e3da9
+        controlVariable:
+          key: officeuse.travelMode
+          type: multicheck
+          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
+          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Flight
+          value: '2'
+      conditionsMustMatch: ALL
+      conditionAction: SHOW
+    - label:
+        en: Flight Number/Registration Number
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: d16a41d4-5247-4907-81fa-b1acf01abfdd
+      type: text
+      binding: officeuse.flightNumber
+      validators: []
+      keyboard: text
+      conditional: true
+      conditions:
+      - uuid: 3cd1b45a-46a2-4903-a4d2-e76c40671de9
+        controlVariable:
+          key: officeuse.travelMode
+          type: multicheck
+          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
+          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
+        operator: equal-to
+        expectedValue:
+          label:
+            en: Flight
+          value: '2'
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Date of Entry
+      hint:
+        en: ''
+      required: true
+      uuid: 8a0eb53b-6921-4ced-bc45-abe9035b228d
+      type: date
+      binding: officeuse.Dateentry
+      dateRules:
+        disableWeekends: false
+      mode: default
+      dateFormat: DD-MM-YYYY
+      defaultDate:
+      minDate:
+      maxDate:
+    - label:
+        en: Time of Entry (optional)
+      mask: 99:99
+      maxlength:
+      minlength:
+      hint:
+        en: '24-Hour time format: HH:MM'
+      required: false
+      uuid: b1a1d6ae-a6c1-4bb8-b7dc-b8162cbea9cc
+      type: text
+      binding: officeuse.Timeentry
+      validators: []
+      keyboard: numeric
+      useMask: true
+      parentLayoutClasses:
+      - flex-100
+    - label:
+        en: Destination
+      required: true
+      api:
+        enabled: false
+        clearOnRefresh: false
+      uuid: 4c02262f-a88d-4503-a20a-5659f9d2c093
+      type: dropdown
+      binding: destionation.structured
+      pickList:
+        en: '{"_id":"5ebc37c481d44d993f63a7ba","organization":"proofgov","team":"demos","titleSlug":"destinations-v1","cuid":"cka5nrgwt00a260nt2l0k2hjb","title":"Destinations
+          V1"}'
+    - label:
+        en: 'If destination is outside Yukon, please specify where:'
+      mask:
+      maxlength:
+      minlength:
+      hint:
+        en: ''
+      required: false
+      uuid: 287343ca-e11a-4207-8902-497df0f0552f
+      type: text
+      binding: destination.other
+      validators: []
+      keyboard: text
+      conditional: true
+      conditions:
+      - uuid: b9135d38-8c7c-4d6d-89f0-39e5b50ea812
+        controlVariable:
+          key: destionation.structured
+          type: dropdown
+          nodeUuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
+          questionUuid: 4c02262f-a88d-4503-a20a-5659f9d2c093
+        operator: equal-to
+        expectedValue: '16'
+      conditionsMustMatch: ANY
+      conditionAction: SHOW
+    - label:
+        en: Identification (provided to verify information on this form)
+      required: false
+      api:
+        enabled: false
+        clearOnRefresh: false
+      uuid: 79172686-6980-4f6c-9a90-00536d072ba9
+      type: dropdown
+      binding: officeuse.ID
+      pickList:
+        en: '{"_id":"5e97a6cd81d44d993f217d5c","organization":"proofgov","team":"demos","titleSlug":"id-yukon-traveller-v2","cuid":"ck921059a009d0yntmv4ajhmt","title":"ID
+          Yukon Traveller V2"}'
+    - label:
+        en: Additional Remarks
+      maxlength:
+      minlength:
+      hint:
+      required: false
+      uuid: 5491b0dc-aecc-476d-82f4-c9492a8cbe88
+      type: long-text
+      binding: officeuse.additionalRemarks
+    label-position: top
+    type: formNode
+    uuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
+    preface:
+    - type: h1
+      text:
+        en: Traveller's Declaration
+      uuid: a49107c4-3ec3-4825-b974-b805f7f5fac1
+      useAsLabel: true
+    subsequentPanelsBehavior: default
+    panelWrapperClasses: ''
+    panelClasses: panel-426507eb-26ef-4657-9ae0-8fda515b9b14
+    canSkipText: Not Applicable / Skip
+    postface: []
+  - nodeLabel: New submissionNode panel
+    noOkayGoBehaviour: true
+    subsequentPanelsBehavior: hidden
+    binding: FORMHERO.SUBMISSION_RESULT
+    button:
+      action: submit
+      text:
+        en: Submit
+    errorHandling:
+      disableSubmitButton: true
+      showErrorNavigator: default
+      message:
+        en: Hold on! There are unanswered questions that must be completed before
+          you can submit.
+      btnLabel:
+        en: Review Missed Questions
+      footerMessage:
+        en: There are incomplete sections that must be filled in before submitting.
+    type: submissionNode
+    uuid: af5eacc5-aa6f-468c-8469-419986d50da9
+    preface:
+    - type: h1
+      text:
+        en: Submit form once all sections completed
+      uuid: ac9de842-1b25-4d0b-81de-c911e00c57f3
+      useAsLabel: true
+    postface: []
+    panelWrapperClasses: ''
+    panelClasses: panel-af5eacc5-aa6f-468c-8469-419986d50da9
+    jsModel: "formHero.on('submit', function(collectedData){\r\n    //Your submission
+      result data: collectedData['FORMHERO.SUBMISSION_RESULT']\r\n    //Add values
+      to updatedData to modify the map of collected data.\r\n    //Example: updatedData['applicant.givenName']
+      = 'Ryan';would set the variable 'applicant.givenName' to 'Ryan'\r\n    //Your
+      Custom Code Starts Here\r\n       \r\n\r\n    //Your Custom Code Ends Here\r\n})"
+  - nodeLabel: END
+    buttons:
+    - text:
+        en: Start Another Submission
+      redirectUrl:
+        en: https://proofgov.formhero.cloud/#/demos/yukon-traveller-form-v3
+      actionWindow: _blank
+      style: Begin
+    hasCloseModalBehaviour: false
+    type: thankyouNode
+    uuid: 20c44dd7-2e54-4de7-839c-afa5d1e0aab4
+    preface:
+    - type: h1
+      text:
+        en: The Yukon Traveller Form has been submitted.
+      uuid: 7a6068a1-075b-43c4-943b-8a008f211416
+      useAsLabel: true
+    postface: []
+    subsequentPanelsBehavior: default
+    useOnChangeJavaScript: false
+    customOnChangeJavaScript: "function onDataChange(immutableData, callback) {\r\n
+      \   //Add values to updatedData to modify the map of collected data.\r\n    //
+      \   Example: updatedData['applicant.givenName'] = 'Ryan'; would set the variable
+      'applicant.givenName' to 'Ryan'\r\n    var updatedData = {};\r\n    //Your Custom
+      Code Starts Here\r\n    \r\n\r\n    //Your Custom Code Ends Here\r\n    callback(updatedData);\r\n}"
+    panelWrapperClasses: ''
+    panelClasses: panel-20c44dd7-2e54-4de7-839c-afa5d1e0aab4
+  edges:
+  - uuid: 837c3694-318b-4d83-aaa5-3f3778026c70
+    from: 74187a6b-6a45-495c-bc6e-fdcb39b30fc7
+    to: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+  - uuid: 7a1a8de9-2b6b-4a65-92b4-c857bf9ebf08
+    to: 426507eb-26ef-4657-9ae0-8fda515b9b14
+    from: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+  - uuid: 8e64ac70-19f7-4e29-b631-ea928a830c17
+    to: af5eacc5-aa6f-468c-8469-419986d50da9
+    from: 426507eb-26ef-4657-9ae0-8fda515b9b14
+  - uuid: 272ab5fe-e5fc-456f-84aa-1ebb1890faeb
+    to: 20c44dd7-2e54-4de7-839c-afa5d1e0aab4
+    from: af5eacc5-aa6f-468c-8469-419986d50da9
+created: '2020-05-15T17:38:31.037Z'
+versionCuid: cka8hjs3h000375ntp0z3sowy
+__v: 0
+outputConfig:
+  f9f7cf5e-eb86-4021-8890-e7fba93a3f29:
+    responseToUser:
+      type: thankYou
+      label: Just Thank the User
+    actions:
+    - type: activity
+      providerType: webhook
+      integrationParams:
+        url: https://app.proofgov.com/api/form_configs/66/submissions
+        httpMethod: POST
+      label: WebHook 66
+      name: WebHook 66
+      providerId: ck8p7rcw101e0lgo6bqw3s272
+      formDesignDetails:
+        headers: []
+        useObjectFormat: false
+        isCustomMessage: false
+        customMessage: ''
+      options:
+        queued: true
+        maxRetryLimit: 10
+        timeoutSecs: 120
+      uuid: 3a0b1277-5b56-4efc-a965-e86a19cb6da1
+  af5eacc5-aa6f-468c-8469-419986d50da9:
+    responseToUser:
+      type: thankYou
+      label: Just Thank the User
+    actions:
+    - type: activity
+      providerType: webhook
+      integrationParams:
+        url: https://yg-form-bridge.proofgov.com/api/form_configs/4/submissions
+        httpMethod: POST
+      label: TRAC yukon traveller v3
+      name: TRAC yukon traveller v3
+      providerId: ck9ikd9mj0hxen2kdxw4w5t9o
+      formDesignDetails:
+        headers: []
+        useObjectFormat: false
+        isCustomMessage: false
+        customMessage: ''
+      options:
+        queued: true
+        maxRetryLimit: 10
+        timeoutSecs: 120
+      uuid: d732f922-5ede-4ebb-ad92-76516203ee96
+cuid: cka8hjs3h000275ntmrydla3t

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,1198 +1,272 @@
 ---
-customScripts: []
-deleted: false
-enableSectionsNavigator: false
-enableSidebar: false
-lastPublishDate: '2020-05-15T17:38:31.459Z'
-originalPublishDate: '2020-04-07T01:13:14.561Z'
-outputArtifacts: []
-pdfReferences: []
-publishStatus: PUBLISHED
-sections: []
-tags: []
-templateFormat: v1.3.9
-version:
-  label: 0.0.27
-  commitMessage: Fixing spelling mistake
-  author:
-    cuid: cjx0n8q49059l0qpjn76mdra9
-    emailAddress: ben@proofgov.com
-  created: '2020-05-15T17:38:31.037Z'
-  smartForm: cka8hjs3h000275ntmrydla3t
-  publishedOn: '2020-05-15T17:38:31.459Z'
-_id: 5ebed3975479080101f5eb48
-browserTitle:
-  en: Yukon Traveller Form
-favicon: https://static.formhero.io/formhero/fh-icon-200.png
-template:
-  languages:
-  - en
-  defaultLang: en
-  showLanguagesSelector: true
-navigation:
-  additionMsg: Press to Enter
-  back:
-    display: true
-    label: Back
-  continue:
-    display: always
-    label: Next
-  skip:
-    label: Not Applicable / Skip
-sidebar:
-  tiles: []
-timeoutConfig:
-  isActive: false
-  sessionDuration: 30
-  idleDuration: 15
-  warningMessage: Your session will expire
-  redirectUrl: https://formhero.com/
-realtimeSummary:
-  enabled: false
-  cols: auto
-  entries: []
-  hideEmpty: false
-  panelLinks: false
-catalogueConfig:
-  type: none
 title: Yukon Traveller Form v3
-organization: proofgov
-team: demos
-slug: yukon-traveller-form-v3
-decisionTree:
-  hasProgressBarCompletion: true
-  nodes:
-  - binding: FORMHERO.USER_LANG
-    buttonText:
-      en: Begin
-    noOkayGoBehaviour: true
-    type: startNode
-    uuid: 74187a6b-6a45-495c-bc6e-fdcb39b30fc7
-    preface:
-    - type: h1
-      text:
-        en: Traveller's Declaration
-      uuid: f2013102-78e5-4cf4-b7da-c839b5835758
-    - type: h3
-      useAsLabel: true
-      text:
-        en: Yukon Government
-      uuid: a24880bc-8d7d-46e0-a009-9a9a9aaddc69
-    level: 0
-    nodeLabel: START
-    subsequentPanelsBehavior: default
-    panelWrapperClasses: ''
-    panelClasses: panel-74187a6b-6a45-495c-bc6e-fdcb39b30fc7
-    displayToUser: false
-    prepopulation: []
-    actionTrigger:
-      type: button
-    postface: []
-  - nodeLabel: Traveller's Declaration
-    fields:
-    - label:
-        en: 'I identify as one of the following:'
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Resident of the Yukon
-        value: '1'
-      - label:
-          en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-            of Canada)
-        value: '2'
-      - label:
-          en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-            of Canada)
-        value: 3
-        uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      uuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-      type: multicheck
-      binding: traveller.Identifier
-      layoutSetting:
-        default:
-          rowHeight: 75
-          columns: 1
-      maximumSelections: 1
-    - label:
-        en: Name
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: true
-      uuid: 7476dcd4-e049-433b-a55b-2dc0ec90e16c
-      type: text
-      binding: traveller.name
-      validators: []
-      keyboard: text
-      conditional: true
-      conditions:
-      - uuid: 67f9e765-1508-4d54-a2e3-bc808a510071
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: 27e0feb5-5c32-4d53-97ec-a1295c384b2b
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: d7144566-c642-451f-b75f-9b2459435d53
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Address of your Residence (where you will be isolating yourself)
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: c35d1657-0c46-4612-aa31-bc45cd3dacf1
-      type: text
-      binding: traveller.Address
-      validators: []
-      keyboard: text
-      parentLayoutClasses:
-      - flex-100
-      conditional: true
-      conditions:
-      - uuid: a2b29940-cb9d-4389-a2fd-2fbae5820505
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: 489ac205-6abb-4544-8426-9e8b254562cc
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 27171042-b484-4e38-b779-4b0730f71638
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Telephone Number (you must be available at this number)
-      mask: "(999) 999-9999"
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: 624e1b2c-fbdd-44b7-b34f-4b4e9f74b241
-      type: text
-      binding: traveller.telephone
-      validators: []
-      keyboard: telephone
-      conditional: true
-      conditions:
-      - uuid: 82e479ff-0172-4d28-bdf2-3a05fb7a2236
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: 5ba7f9c9-d339-4f9e-9cd3-daca0ce22c8a
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 6654c9b1-ec70-4c4f-b3eb-3860c1fe054e
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-      useMask: true
-    - label:
-        en: Purpose of Entry
-      required: true
-      api:
-        enabled: false
-        clearOnRefresh: false
-      uuid: a21c1431-413e-49b7-802d-452d35cca403
-      type: dropdown
-      binding: entry.purpose
-      pickList:
-        en: '{"_id":"5e9a1ad481d44d993f7dc352","organization":"proofgov","team":"demos","titleSlug":"purpose-of-entry-covid-travel","cuid":"ck94oq3ku00cu0kntxfw0itx3","title":"Purpose
-          of Entry COVID Travel"}'
-      conditional: true
-      conditions:
-      - uuid: 11281366-64b2-4888-a848-c78801036daf
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: d4e59b3a-88e6-4928-ac30-0943113b7a48
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 5b5be06d-0888-41c8-b4dd-8e576aca6999
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-      hint:
-        en: ''
-    - label:
-        en: Documentation to support your purpose for entering the Yukon
-      maxlength:
-      minlength:
-      hint:
-      required: false
-      uuid: 3c8b73c3-2065-4f31-b3d5-cb2ae94895f6
-      type: long-text
-      binding: support.entrydocument
-      conditional: true
-      conditions:
-      - uuid: 0a91579e-2dfb-4187-8156-46c83f6315cb
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: f26dcd4b-a2ab-4bc9-9d13-394092bcd858
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 2e13f85a-210e-4b2e-b793-40f6f717390d
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Have you been outside Canada in the last 14 days?
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: 'Yes'
-        value: '1'
-      - label:
-          en: 'No'
-        value: '2'
-      uuid: 9d8b5185-1860-47e0-8b97-3bdae5a51747
-      type: multicheck
-      binding: outside.canada
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      maximumSelections: 1
-      conditional: true
-      conditions:
-      - uuid: 4c1b1bac-705a-4c6c-a6dd-e5c040fb3856
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: e1453121-67a9-4af6-af4e-b69b8dbe884c
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 5401d513-ca9f-47ed-96a6-2da27a81a35b
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: What locations have you visited in the last 14 days?
-      maxlength:
-      minlength:
-      hint:
-        en: All communities, provinces, territories and countries
-      required: false
-      uuid: ac02e24f-a223-4fbc-8805-b4c3fb84a03e
-      type: long-text
-      binding: locations.visited14days
-      conditional: true
-      conditions:
-      - uuid: 8d82c8df-64c3-40e9-b422-92b9e321c265
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: b312eccc-1da2-45e6-9430-87791e883892
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 633af525-8d2b-4992-b1b8-222d3fcbc8f5
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Isolation plan/Plan after 14 day isolation complete
-      maxlength:
-      minlength:
-      hint:
-      required: false
-      uuid: 9d7c5a4b-8056-441d-a6f5-f8cc09ab3b21
-      type: long-text
-      binding: nonresident.nottransitPlan
-      conditional: true
-      conditions:
-      - uuid: c6e81b80-03ce-4198-aa30-cece49cf85a3
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: Plan travelling through Yukon
-      maxlength:
-      minlength:
-      hint:
-        en: Include route, businesses you will visit, time and location of exit from
-          Yukon
-      required: false
-      uuid: 1ca7c8db-212f-485b-b122-6539c196db30
-      type: long-text
-      binding: nonresident.transitPlan
-      conditional: true
-      conditions:
-      - uuid: de5bd468-b1ad-4daa-9a21-6f491d9bbf67
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: This information is true and correct. I am aware that if I am granted
-          entry to Yukon, the Chief Medical Officer of Health requires me to self-isolate
-          for 14 days. If I am defined as an essential service, I must self-isolate
-          for 14 days. If I am defined as a critical service, I am required to follow
-          the direction and guidelines for the delivery of critical services. I am
-          also aware that I must act in accordance with this declaration and any enforcement
-          orders or health emergency orders related to COVID-19.
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Agree
-        value: '1'
-      - label:
-          en: Disagree
-        value: '2'
-      uuid: f3de75c3-5e75-4c24-8665-3942acb777b1
-      type: multicheck
-      binding: resident.yukonDeclaration
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      maximumSelections: 1
-      parentLayoutClasses:
-      - flex-100
-      conditional: true
-      conditions:
-      - uuid: 0bd6fed6-b7d9-4a15-b525-44301ba35db8
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: Do you have any COVID-19 symptoms?
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: I have symptoms
-        value: '1'
-      - label:
-          en: No symptoms
-        value: '2'
-      uuid: 37c8c52a-4b2b-4d34-a619-1e97b1d38f26
-      type: multicheck
-      binding: covid.SymptomYesNo
-      layoutSetting:
-        default:
-          rowHeight: 75
-          columns: 3
-      maximumSelections: 1
-      parentLayoutClasses:
-      - flex-100
-      conditional: true
-      conditions:
-      - uuid: 93af8dc7-199e-452a-8137-5ef34f78462c
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Resident of the Yukon
-          value: '1'
-      - uuid: bbac81cd-e471-4191-8f7a-fbfe81eeebaf
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      - uuid: 22e926b7-4ab4-4a21-a6a7-c839b081bebc
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: What symptoms are you experiencing?
-      hint:
-        en: Select all that apply
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Cough
-        value: '1'
-      - label:
-          en: Fever
-        value: '2'
-      - label:
-          en: Difficulty breathing
-        value: 3
-        uuid: a4915da1-b195-4721-83d8-a8ed9441660a
-      uuid: 5689b9d9-a75b-4995-b91f-e7140812ddf3
-      type: multicheck
-      binding: covid.Symptoms
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      info:
-        en: If you have any of these symptoms, call 811 on arrival at your residence.
-      maximumSelections: 3
-      conditional: true
-      conditions:
-      - uuid: 63be4419-36d7-45f7-83f0-805ae2845dab
-        controlVariable:
-          key: covid.SymptomYesNo
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 37c8c52a-4b2b-4d34-a619-1e97b1d38f26
-        operator: equal-to
-        expectedValue:
-          label:
-            en: I have symptoms
-          value: '1'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: This information is true and correct. I am aware that if I am granted
-          entry to Yukon, the Chief Medical Officer of Health requires me to self-isolate
-          for 14 days. If I am defined as an essential service, I must self-isolate
-          for 14 days. If I am defined as a critical service, I am required to follow
-          the direction and guidelines for the delivery of critical services. I am
-          also aware that I must act in accordance with this declaration and any enforcement
-          orders or health emergency orders related to COVID-19.
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Agree
-        value: '1'
-      - label:
-          en: Disagree
-        value: '2'
-      uuid: 2ca34cbc-0275-489b-9356-33500bce8382
-      type: multicheck
-      binding: nonresident.nottransitDeclaration
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      maximumSelections: 1
-      conditional: true
-      conditions:
-      - uuid: a83fa9c0-5f04-4ab9-8377-e70694457560
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Not for transit to Alaska or other parts
-              of Canada)
-          value: '2'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: This information is true and correct. I am aware that the Civil Emergency
-          Measures Health Protection Order requires me to complete my transit of Yukon
-          within 24 hours of entry. Failure to comply with the Orders is punishable
-          by Law.
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Agree
-        value: '1'
-      - label:
-          en: Disagree
-        value: '2'
-      uuid: 5e01da96-ce32-4599-b7e9-93b3ea0d1bb7
-      type: multicheck
-      binding: nonresident.transitDeclaration
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      maximumSelections: 1
-      conditional: true
-      conditions:
-      - uuid: 5d9b786b-6cd9-4944-8853-973416b2a112
-        controlVariable:
-          key: traveller.Identifier
-          type: multicheck
-          nodeUuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-          questionUuid: 429187d8-51fa-45bc-90a7-00aa940fe9c4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Non-Resident of the Yukon (Only for transit to Alaska or other parts
-              of Canada)
-          value: 3
-          uuid: 29539ba6-efd5-4476-a190-c4586aeb4b93
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    label-position: top
-    type: formNode
-    uuid: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-    preface:
-    - type: h1
-      text:
-        en: Traveller's Declaration
-      uuid: 3c1f070e-26e2-40e9-9c76-ecb214b13130
-      useAsLabel: true
-    subsequentPanelsBehavior: default
-    panelWrapperClasses: ''
-    panelClasses: panel-582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-    canSkipText: Not Applicable / Skip
-    postface: []
-    useOnChangeJavaScript: true
-    customOnChangeJavaScript: "function onDataChange(immutableData, callback) {\r\n
-      \   //Add values to updatedData to modify the map of collected data.\r\n    //
-      \   Example: updatedData['applicant.givenName'] = 'Ryan'; would set the variable
-      'applicant.givenName' to 'Ryan'\r\n    var updatedData = {};\r\n    //Your Custom
-      Code Starts Here\r\n    function formatDate(date) {\r\n        dateToFormat
-      = new Date(date);\r\n        mm = (\"0\" + ((new Date(date).getMonth() + 1))).slice(-2);\r\n
-      \       dd = (\"0\" + (new Date(date).getDate())).slice(-2);\r\n        yyyy
-      = new Date(date).getFullYear();\r\n        formattedDate = yyyy + \"-\" + mm
-      + \"-\" + dd;\r\n        return formattedDate\r\n    }\r\n\r\n    let today
-      \ = new Date();\r\n    updatedData['officeuse.Dateentry'] = formatDate(today);\r\n\r\n
-      \   //Your Custom Code Ends Here\r\n    callback(updatedData);\r\n}"
-  - nodeLabel: Traveller's Declaration
-    fields:
-    - label:
-        en: Point of Entry
-      required: true
-      api:
-        enabled: false
-        clearOnRefresh: false
-      uuid: 7b2eee87-0f8d-4384-a983-309d3c6f0729
-      type: dropdown
-      binding: pointofentry.Travel
-      pickList:
-        en: '{"_id":"5e9f46df81d44d993f31ad11","organization":"proofgov","team":"demos","titleSlug":"17-points-of-entry","cuid":"ck9aaj3hb00j30io1ynd9vl07","title":"17
-          Points of Entry"}'
-      conditional: false
-      conditions:
-      - uuid: '084d3efd-3806-462d-89e9-c1302af20b77'
-        controlVariable:
-          key: officeuse.travelMode
-          type: multicheck
-          nodeUuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
-          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Vehicle
-          value: '1'
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Travel Mode
-      hint:
-        en: ''
-      errorMessages:
-        selectionCount:
-          fail: We need you to pick more options.
-          pass: You've picked as many as we need you to.
-      minimumSelections: 1
-      options:
-      - label:
-          en: Vehicle
-        value: '1'
-      - label:
-          en: Flight
-        value: '2'
-      uuid: 8323173b-9f50-4f90-822a-d99c309f09f4
-      type: multicheck
-      binding: officeuse.travelMode
-      layoutSetting:
-        default:
-          rowHeight: 55
-          columns: 3
-      maximumSelections: 1
-      conditional: false
-      conditions:
-      - uuid: 7988d053-a1cf-4216-a91a-19ca58e3e552
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: License Plate
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: cf401498-671d-4572-9a01-062a1395997f
-      type: text
-      binding: officeuser.Licenseplate
-      validators: []
-      keyboard: text
-      conditional: true
-      conditions:
-      - uuid: b39c5f78-6c08-4924-abba-0b12f4d40fe5
-        controlVariable:
-          key: officeuse.travelMode
-          type: multicheck
-          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
-          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Car
-          value: '1'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: Airline
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: e434d84a-6907-4551-80e6-1967a177a055
-      type: text
-      binding: officeuser.Airline
-      validators: []
-      keyboard: text
-      conditional: true
-      conditions:
-      - uuid: 19a4fa14-2c77-4a52-bd34-f403c34e3da9
-        controlVariable:
-          key: officeuse.travelMode
-          type: multicheck
-          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
-          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Flight
-          value: '2'
-      conditionsMustMatch: ALL
-      conditionAction: SHOW
-    - label:
-        en: Flight Number/Registration Number
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: d16a41d4-5247-4907-81fa-b1acf01abfdd
-      type: text
-      binding: officeuse.flightNumber
-      validators: []
-      keyboard: text
-      conditional: true
-      conditions:
-      - uuid: 3cd1b45a-46a2-4903-a4d2-e76c40671de9
-        controlVariable:
-          key: officeuse.travelMode
-          type: multicheck
-          nodeUuid: 966b48fd-1e51-41bf-9572-653a3e87c1cd
-          questionUuid: 8323173b-9f50-4f90-822a-d99c309f09f4
-        operator: equal-to
-        expectedValue:
-          label:
-            en: Flight
-          value: '2'
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Date of Entry
-      hint:
-        en: ''
-      required: true
-      uuid: 8a0eb53b-6921-4ced-bc45-abe9035b228d
-      type: date
-      binding: officeuse.Dateentry
-      dateRules:
-        disableWeekends: false
-      mode: default
-      dateFormat: DD-MM-YYYY
-      defaultDate:
-      minDate:
-      maxDate:
-    - label:
-        en: Time of Entry (optional)
-      mask: 99:99
-      maxlength:
-      minlength:
-      hint:
-        en: '24-Hour time format: HH:MM'
-      required: false
-      uuid: b1a1d6ae-a6c1-4bb8-b7dc-b8162cbea9cc
-      type: text
-      binding: officeuse.Timeentry
-      validators: []
-      keyboard: numeric
-      useMask: true
-      parentLayoutClasses:
-      - flex-100
-    - label:
-        en: Destination
-      required: true
-      api:
-        enabled: false
-        clearOnRefresh: false
-      uuid: 4c02262f-a88d-4503-a20a-5659f9d2c093
-      type: dropdown
-      binding: destionation.structured
-      pickList:
-        en: '{"_id":"5ebc37c481d44d993f63a7ba","organization":"proofgov","team":"demos","titleSlug":"destinations-v1","cuid":"cka5nrgwt00a260nt2l0k2hjb","title":"Destinations
-          V1"}'
-    - label:
-        en: 'If destination is outside Yukon, please specify where:'
-      mask:
-      maxlength:
-      minlength:
-      hint:
-        en: ''
-      required: false
-      uuid: 287343ca-e11a-4207-8902-497df0f0552f
-      type: text
-      binding: destination.other
-      validators: []
-      keyboard: text
-      conditional: true
-      conditions:
-      - uuid: b9135d38-8c7c-4d6d-89f0-39e5b50ea812
-        controlVariable:
-          key: destionation.structured
-          type: dropdown
-          nodeUuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
-          questionUuid: 4c02262f-a88d-4503-a20a-5659f9d2c093
-        operator: equal-to
-        expectedValue: '16'
-      conditionsMustMatch: ANY
-      conditionAction: SHOW
-    - label:
-        en: Identification (provided to verify information on this form)
-      required: false
-      api:
-        enabled: false
-        clearOnRefresh: false
-      uuid: 79172686-6980-4f6c-9a90-00536d072ba9
-      type: dropdown
-      binding: officeuse.ID
-      pickList:
-        en: '{"_id":"5e97a6cd81d44d993f217d5c","organization":"proofgov","team":"demos","titleSlug":"id-yukon-traveller-v2","cuid":"ck921059a009d0yntmv4ajhmt","title":"ID
-          Yukon Traveller V2"}'
-    - label:
-        en: Additional Remarks
-      maxlength:
-      minlength:
-      hint:
-      required: false
-      uuid: 5491b0dc-aecc-476d-82f4-c9492a8cbe88
-      type: long-text
-      binding: officeuse.additionalRemarks
-    label-position: top
-    type: formNode
-    uuid: 426507eb-26ef-4657-9ae0-8fda515b9b14
-    preface:
-    - type: h1
-      text:
-        en: Traveller's Declaration
-      uuid: a49107c4-3ec3-4825-b974-b805f7f5fac1
-      useAsLabel: true
-    subsequentPanelsBehavior: default
-    panelWrapperClasses: ''
-    panelClasses: panel-426507eb-26ef-4657-9ae0-8fda515b9b14
-    canSkipText: Not Applicable / Skip
-    postface: []
-  - nodeLabel: New submissionNode panel
-    noOkayGoBehaviour: true
-    subsequentPanelsBehavior: hidden
-    binding: FORMHERO.SUBMISSION_RESULT
-    button:
-      action: submit
-      text:
-        en: Submit
-    errorHandling:
-      disableSubmitButton: true
-      showErrorNavigator: default
-      message:
-        en: Hold on! There are unanswered questions that must be completed before
-          you can submit.
-      btnLabel:
-        en: Review Missed Questions
-      footerMessage:
-        en: There are incomplete sections that must be filled in before submitting.
-    type: submissionNode
-    uuid: af5eacc5-aa6f-468c-8469-419986d50da9
-    preface:
-    - type: h1
-      text:
-        en: Submit form once all sections completed
-      uuid: ac9de842-1b25-4d0b-81de-c911e00c57f3
-      useAsLabel: true
-    postface: []
-    panelWrapperClasses: ''
-    panelClasses: panel-af5eacc5-aa6f-468c-8469-419986d50da9
-    jsModel: "formHero.on('submit', function(collectedData){\r\n    //Your submission
-      result data: collectedData['FORMHERO.SUBMISSION_RESULT']\r\n    //Add values
-      to updatedData to modify the map of collected data.\r\n    //Example: updatedData['applicant.givenName']
-      = 'Ryan';would set the variable 'applicant.givenName' to 'Ryan'\r\n    //Your
-      Custom Code Starts Here\r\n       \r\n\r\n    //Your Custom Code Ends Here\r\n})"
-  - nodeLabel: END
-    buttons:
-    - text:
-        en: Start Another Submission
-      redirectUrl:
-        en: https://proofgov.formhero.cloud/#/demos/yukon-traveller-form-v3
-      actionWindow: _blank
-      style: Begin
-    hasCloseModalBehaviour: false
-    type: thankyouNode
-    uuid: 20c44dd7-2e54-4de7-839c-afa5d1e0aab4
-    preface:
-    - type: h1
-      text:
-        en: The Yukon Traveller Form has been submitted.
-      uuid: 7a6068a1-075b-43c4-943b-8a008f211416
-      useAsLabel: true
-    postface: []
-    subsequentPanelsBehavior: default
-    useOnChangeJavaScript: false
-    customOnChangeJavaScript: "function onDataChange(immutableData, callback) {\r\n
-      \   //Add values to updatedData to modify the map of collected data.\r\n    //
-      \   Example: updatedData['applicant.givenName'] = 'Ryan'; would set the variable
-      'applicant.givenName' to 'Ryan'\r\n    var updatedData = {};\r\n    //Your Custom
-      Code Starts Here\r\n    \r\n\r\n    //Your Custom Code Ends Here\r\n    callback(updatedData);\r\n}"
-    panelWrapperClasses: ''
-    panelClasses: panel-20c44dd7-2e54-4de7-839c-afa5d1e0aab4
-  edges:
-  - uuid: 837c3694-318b-4d83-aaa5-3f3778026c70
-    from: 74187a6b-6a45-495c-bc6e-fdcb39b30fc7
-    to: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-  - uuid: 7a1a8de9-2b6b-4a65-92b4-c857bf9ebf08
-    to: 426507eb-26ef-4657-9ae0-8fda515b9b14
-    from: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
-  - uuid: 8e64ac70-19f7-4e29-b631-ea928a830c17
-    to: af5eacc5-aa6f-468c-8469-419986d50da9
-    from: 426507eb-26ef-4657-9ae0-8fda515b9b14
-  - uuid: 272ab5fe-e5fc-456f-84aa-1ebb1890faeb
-    to: 20c44dd7-2e54-4de7-839c-afa5d1e0aab4
-    from: af5eacc5-aa6f-468c-8469-419986d50da9
-created: '2020-05-15T17:38:31.037Z'
-versionCuid: cka8hjs3h000375ntp0z3sowy
-__v: 0
-outputConfig:
-  f9f7cf5e-eb86-4021-8890-e7fba93a3f29:
-    responseToUser:
-      type: thankYou
-      label: Just Thank the User
-    actions:
-    - type: activity
-      providerType: webhook
-      integrationParams:
-        url: https://app.proofgov.com/api/form_configs/66/submissions
-        httpMethod: POST
-      label: WebHook 66
-      name: WebHook 66
-      providerId: ck8p7rcw101e0lgo6bqw3s272
-      formDesignDetails:
-        headers: []
-        useObjectFormat: false
-        isCustomMessage: false
-        customMessage: ''
-      options:
-        queued: true
-        maxRetryLimit: 10
-        timeoutSecs: 120
-      uuid: 3a0b1277-5b56-4efc-a965-e86a19cb6da1
-  af5eacc5-aa6f-468c-8469-419986d50da9:
-    responseToUser:
-      type: thankYou
-      label: Just Thank the User
-    actions:
-    - type: activity
-      providerType: webhook
-      integrationParams:
-        url: https://yg-form-bridge.proofgov.com/api/form_configs/4/submissions
-        httpMethod: POST
-      label: TRAC yukon traveller v3
-      name: TRAC yukon traveller v3
-      providerId: ck9ikd9mj0hxen2kdxw4w5t9o
-      formDesignDetails:
-        headers: []
-        useObjectFormat: false
-        isCustomMessage: false
-        customMessage: ''
-      options:
-        queued: true
-        maxRetryLimit: 10
-        timeoutSecs: 120
-      uuid: d732f922-5ede-4ebb-ad92-76516203ee96
+id: 5ebed3975479080101f5eb48
 cuid: cka8hjs3h000275ntmrydla3t
+created_at: '2020-05-15T17:38:31.037Z'
+sections:
+- id: 582c9e6c-5fd9-47e1-bc37-16a1b6c3cb02
+  label: Traveller's Declaration
+  fields:
+  - id: 429187d8-51fa-45bc-90a7-00aa940fe9c4
+    label: 'I identify as one of the following:'
+    binding: traveller.Identifier
+    type: multicheck
+    choices:
+    - label: Resident of the Yukon
+      value: '1'
+    - label: Non-Resident of the Yukon (Not for transit to Alaska or other parts of
+        Canada)
+      value: '2'
+    - label: Non-Resident of the Yukon (Only for transit to Alaska or other parts
+        of Canada)
+      value: 3
+  - id: 7476dcd4-e049-433b-a55b-2dc0ec90e16c
+    label: Name
+    binding: traveller.name
+    type: text
+  - id: c35d1657-0c46-4612-aa31-bc45cd3dacf1
+    label: Address of your Residence (where you will be isolating yourself)
+    binding: traveller.Address
+    type: text
+  - id: 624e1b2c-fbdd-44b7-b34f-4b4e9f74b241
+    label: Telephone Number (you must be available at this number)
+    binding: traveller.telephone
+    type: text
+  - id: a21c1431-413e-49b7-802d-452d35cca403
+    label: Purpose of Entry
+    binding: entry.purpose
+    type: dropdown
+    choices:
+    - label: Travel to my place of residence in Yukon
+      value: '1'
+    - label: Stay with a family member at their place of residence in Yukon
+      value: '2'
+    - label: Provide critical or essential services in Yukon or in the BC-Yukon border
+        area
+      value: '3'
+    - label: Transit through Yukon as described in subsection 2(3) of the Health Order
+      value: '4'
+    - label: Engage in activities described in the Traditional Activities Order
+      value: '5'
+  - id: 3c8b73c3-2065-4f31-b3d5-cb2ae94895f6
+    label: Documentation to support your purpose for entering the Yukon
+    binding: support.entrydocument
+    type: long-text
+  - id: 9d8b5185-1860-47e0-8b97-3bdae5a51747
+    label: Have you been outside Canada in the last 14 days?
+    binding: outside.canada
+    type: multicheck
+    choices:
+    - label: 'Yes'
+      value: '1'
+    - label: 'No'
+      value: '2'
+  - id: ac02e24f-a223-4fbc-8805-b4c3fb84a03e
+    label: What locations have you visited in the last 14 days?
+    binding: locations.visited14days
+    type: long-text
+  - id: 9d7c5a4b-8056-441d-a6f5-f8cc09ab3b21
+    label: Isolation plan/Plan after 14 day isolation complete
+    binding: nonresident.nottransitPlan
+    type: long-text
+  - id: 1ca7c8db-212f-485b-b122-6539c196db30
+    label: Plan travelling through Yukon
+    binding: nonresident.transitPlan
+    type: long-text
+  - id: f3de75c3-5e75-4c24-8665-3942acb777b1
+    label: This information is true and correct. I am aware that if I am granted entry
+      to Yukon, the Chief Medical Officer of Health requires me to self-isolate for
+      14 days. If I am defined as an essential service, I must self-isolate for 14
+      days. If I am defined as a critical service, I am required to follow the direction
+      and guidelines for the delivery of critical services. I am also aware that I
+      must act in accordance with this declaration and any enforcement orders or health
+      emergency orders related to COVID-19.
+    binding: resident.yukonDeclaration
+    type: multicheck
+    choices:
+    - label: Agree
+      value: '1'
+    - label: Disagree
+      value: '2'
+  - id: 37c8c52a-4b2b-4d34-a619-1e97b1d38f26
+    label: Do you have any COVID-19 symptoms?
+    binding: covid.SymptomYesNo
+    type: multicheck
+    choices:
+    - label: I have symptoms
+      value: '1'
+    - label: No symptoms
+      value: '2'
+  - id: 5689b9d9-a75b-4995-b91f-e7140812ddf3
+    label: What symptoms are you experiencing?
+    binding: covid.Symptoms
+    type: multicheck
+    choices:
+    - label: Cough
+      value: '1'
+    - label: Fever
+      value: '2'
+    - label: Difficulty breathing
+      value: 3
+  - id: 2ca34cbc-0275-489b-9356-33500bce8382
+    label: This information is true and correct. I am aware that if I am granted entry
+      to Yukon, the Chief Medical Officer of Health requires me to self-isolate for
+      14 days. If I am defined as an essential service, I must self-isolate for 14
+      days. If I am defined as a critical service, I am required to follow the direction
+      and guidelines for the delivery of critical services. I am also aware that I
+      must act in accordance with this declaration and any enforcement orders or health
+      emergency orders related to COVID-19.
+    binding: nonresident.nottransitDeclaration
+    type: multicheck
+    choices:
+    - label: Agree
+      value: '1'
+    - label: Disagree
+      value: '2'
+  - id: 5e01da96-ce32-4599-b7e9-93b3ea0d1bb7
+    label: This information is true and correct. I am aware that the Civil Emergency
+      Measures Health Protection Order requires me to complete my transit of Yukon
+      within 24 hours of entry. Failure to comply with the Orders is punishable by
+      Law.
+    binding: nonresident.transitDeclaration
+    type: multicheck
+    choices:
+    - label: Agree
+      value: '1'
+    - label: Disagree
+      value: '2'
+- id: 426507eb-26ef-4657-9ae0-8fda515b9b14
+  label: Traveller's Declaration
+  fields:
+  - id: 7b2eee87-0f8d-4384-a983-309d3c6f0729
+    label: Point of Entry
+    binding: pointofentry.Travel
+    type: dropdown
+    choices:
+    - label: Whitehorse Airport
+      value: '1'
+    - label: Alaska Hwy
+      value: '2'
+    - label: Stewart Cassiar Hwy
+      value: '3'
+    - label: Dempster Hwy
+      value: '4'
+    - label: Dawson City Airport
+      value: '5'
+    - label: Watson Lake Airport
+      value: '6'
+    - label: Mayo Airport
+      value: '7'
+    - label: Beaver Creek Airport
+      value: '8'
+    - label: Burwash Landing Airport
+      value: '9'
+    - label: Carcross Airport
+      value: '10'
+    - label: Carmacks Airport
+      value: '11'
+    - label: Faro Airport
+      value: '12'
+    - label: Haines Junction Airport
+      value: '13'
+    - label: Old Crow Airport
+      value: '14'
+    - label: Pelly Crossing Airport
+      value: '15'
+    - label: Ross River Airport
+      value: '16'
+    - label: Teslin Airport
+      value: '17'
+  - id: 8323173b-9f50-4f90-822a-d99c309f09f4
+    label: Travel Mode
+    binding: officeuse.travelMode
+    type: multicheck
+    choices:
+    - label: Vehicle
+      value: '1'
+    - label: Flight
+      value: '2'
+  - id: cf401498-671d-4572-9a01-062a1395997f
+    label: License Plate
+    binding: officeuser.Licenseplate
+    type: text
+  - id: e434d84a-6907-4551-80e6-1967a177a055
+    label: Airline
+    binding: officeuser.Airline
+    type: text
+  - id: d16a41d4-5247-4907-81fa-b1acf01abfdd
+    label: Flight Number/Registration Number
+    binding: officeuse.flightNumber
+    type: text
+  - id: 8a0eb53b-6921-4ced-bc45-abe9035b228d
+    label: Date of Entry
+    binding: officeuse.Dateentry
+    type: date
+  - id: b1a1d6ae-a6c1-4bb8-b7dc-b8162cbea9cc
+    label: Time of Entry (optional)
+    binding: officeuse.Timeentry
+    type: text
+  - id: 4c02262f-a88d-4503-a20a-5659f9d2c093
+    label: Destination
+    binding: destionation.structured
+    type: dropdown
+    choices:
+    - label: Whitehorse
+      value: '1'
+    - label: Beaver Creek
+      value: '2'
+    - label: Burwash Landing
+      value: '3'
+    - label: Carcross and Tagish
+      value: '4'
+    - label: Carmacks
+      value: '5'
+    - label: Dawson City
+      value: '6'
+    - label: Faro
+      value: '7'
+    - label: Haines Junction
+      value: '8'
+    - label: Mayo
+      value: '9'
+    - label: Mount Lorne
+      value: '10'
+    - label: Old Crow
+      value: '11'
+    - label: Pelly Crossing
+      value: '12'
+    - label: Ross River
+      value: '13'
+    - label: Teslin
+      value: '14'
+    - label: Watson Lake
+      value: '15'
+    - label: Outside Yukon
+      value: '16'
+  - id: 287343ca-e11a-4207-8902-497df0f0552f
+    label: 'If destination is outside Yukon, please specify where:'
+    binding: destination.other
+    type: text
+  - id: 79172686-6980-4f6c-9a90-00536d072ba9
+    label: Identification (provided to verify information on this form)
+    binding: officeuse.ID
+    type: dropdown
+    choices:
+    - label: Passport
+      value: '1'
+    - label: Birth Certificate
+      value: '2'
+    - label: Driver's License
+      value: '3'
+    - label: Canadian military identification card
+      value: '4'
+    - label: Government-issued identification card
+      value: '5'
+    - label: Canadian citizenship card
+      value: '6'
+    - label: Status card
+      value: '7'
+  - id: 5491b0dc-aecc-476d-82f4-c9492a8cbe88
+    label: Additional Remarks
+    binding: officeuse.additionalRemarks
+    type: long-text

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -9,6 +9,9 @@ const utilsDir = path.dirname(__filename)
 const providerInfoPath = path.resolve(utilsDir, '../provider_info.yaml')
 const schemaPath = path.resolve(utilsDir, '../schema.yaml')
 
+const { PROOF_URL } = process.env
+const { protocol, hostname, port } = url.parse(PROOF_URL)
+
 function loadProviderInfo () {
   let providerInfo
   try {
@@ -54,8 +57,6 @@ function loadSchema () {
 }
 
 function selectRequestLibrary () {
-  const { PROOF_URL } = process.env
-  const { protocol } = url.parse(PROOF_URL)
   return protocol === 'https:' ? https : http
 }
 
@@ -64,4 +65,7 @@ module.exports = {
   saveProviderInfo,
   loadSchema,
   requester: selectRequestLibrary(),
+  protocol,
+  hostname,
+  port,
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,0 +1,44 @@
+var path = require('path')
+const fs = require('fs')
+const yaml = require('js-yaml')
+
+const utilsDir = path.dirname(__filename)
+const providerInfoPath = path.resolve(utilsDir, '../provider_info.yaml')
+
+function loadProviderInfo () {
+  let providerInfo
+  try {
+    providerInfo = yaml.safeLoad(fs.readFileSync(providerInfoPath, 'utf8'))
+  } catch (error) {
+    providerInfo = {}
+  }
+
+  const { PROOF_FORM_ID, PROOF_FORM_PROVIDER, PROOF_FORM_PROVIDER_ID } = process.env
+
+  return {
+    provider: PROOF_FORM_PROVIDER || providerInfo.provider || 'proof',
+    providerIdentifier:
+      PROOF_FORM_PROVIDER_ID ||
+      providerInfo.providerIdentifier ||
+      `proof/form-example/${Date.now()}`,
+    id: PROOF_FORM_ID || providerInfo.id || null
+  }
+}
+
+
+function saveProviderInfo ({ provider, providerIdentifier, id }) {
+  try {
+    fs.writeFileSync(
+      providerInfoPath,
+      yaml.safeDump({ provider, providerIdentifier, id }),
+      'utf8'
+    )
+  } catch (error) {
+    console.log('error =', error)
+  }
+}
+
+module.exports = {
+  loadProviderInfo,
+  saveProviderInfo
+}

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -50,8 +50,15 @@ function loadSchema () {
   }
 }
 
+function selectRequestLibrary () {
+  const { PROOF_URL } = process.env
+  const { protocol } = url.parse(PROOF_URL)
+  return protocol === 'https:' ? require('https') : require('http')
+}
+
 module.exports = {
   loadProviderInfo,
   saveProviderInfo,
   loadSchema,
+  requester: selectRequestLibrary(),
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -4,6 +4,7 @@ const yaml = require('js-yaml')
 
 const utilsDir = path.dirname(__filename)
 const providerInfoPath = path.resolve(utilsDir, '../provider_info.yaml')
+const schemaPath = path.resolve(utilsDir, '../schema.yaml')
 
 function loadProviderInfo () {
   let providerInfo
@@ -13,7 +14,11 @@ function loadProviderInfo () {
     providerInfo = {}
   }
 
-  const { PROOF_FORM_ID, PROOF_FORM_PROVIDER, PROOF_FORM_PROVIDER_ID } = process.env
+  const {
+    PROOF_FORM_ID,
+    PROOF_FORM_PROVIDER,
+    PROOF_FORM_PROVIDER_ID,
+  } = process.env
 
   return {
     provider: PROOF_FORM_PROVIDER || providerInfo.provider || 'proof',
@@ -21,10 +26,9 @@ function loadProviderInfo () {
       PROOF_FORM_PROVIDER_ID ||
       providerInfo.providerIdentifier ||
       `proof/form-example/${Date.now()}`,
-    id: PROOF_FORM_ID || providerInfo.id || null
+    id: PROOF_FORM_ID || providerInfo.id || null,
   }
 }
-
 
 function saveProviderInfo ({ provider, providerIdentifier, id }) {
   try {
@@ -38,7 +42,16 @@ function saveProviderInfo ({ provider, providerIdentifier, id }) {
   }
 }
 
+function loadSchema () {
+  try {
+    return yaml.safeLoad(fs.readFileSync(schemaPath, 'utf8'))
+  } catch (error) {
+    console.log(error)
+  }
+}
+
 module.exports = {
   loadProviderInfo,
-  saveProviderInfo
+  saveProviderInfo,
+  loadSchema,
 }

--- a/utils/helpers.js
+++ b/utils/helpers.js
@@ -1,5 +1,8 @@
-var path = require('path')
 const fs = require('fs')
+const http = require('http')
+const https = require('https')
+const path = require('path')
+const url = require('url')
 const yaml = require('js-yaml')
 
 const utilsDir = path.dirname(__filename)
@@ -53,7 +56,7 @@ function loadSchema () {
 function selectRequestLibrary () {
   const { PROOF_URL } = process.env
   const { protocol } = url.parse(PROOF_URL)
-  return protocol === 'https:' ? require('https') : require('http')
+  return protocol === 'https:' ? https : http
 }
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,6 +82,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+docopt@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
+  integrity sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -142,6 +147,11 @@ express@^4.17.1:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+faker@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/faker/-/faker-4.1.0.tgz#1e45bbbecc6774b3c195fad2835109c6d748cc3f"
+  integrity sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=
 
 finalhandler@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,13 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -89,6 +96,11 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
+
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -197,6 +209,14 @@ ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 media-typer@0.3.0:
   version "0.3.0"
@@ -333,6 +353,11 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"


### PR DESCRIPTION
### Overview
Add a binary that when run
- starting with a `PROOF_URL` and a `PROOF_FORM_ID`,
- running this binary will arrange for the attached form schema to be set as the latest for this form.

### Testing Instructions
1. Boot up the local app (core-app -> dev boot)
2. Create an Api token in the PROOF app vai
`ApiToken.create! user: User.find(1)` and copy the `token` field (without qoutes) into the appropriate field in the next step.
3. Set up an `.envrc` file with:
```bash
export PROOF_URL=http://localhost:3000
export PROOF_API_TOKEN=<some-token>
```
4. Try some submission options
- `bin/setup-form --dry-run`
- `bin/setup-form`